### PR TITLE
[Fix] Report post API 500 에러 문제 해결

### DIFF
--- a/bdink/src/main/java/com/app/bdink/report/controller/ReportController.java
+++ b/bdink/src/main/java/com/app/bdink/report/controller/ReportController.java
@@ -6,6 +6,7 @@ import com.app.bdink.report.controller.dto.request.ReportDto;
 import com.app.bdink.report.controller.dto.response.ReportResponse;
 import com.app.bdink.report.domain.ReportCase;
 import com.app.bdink.report.service.ReportService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -20,6 +21,9 @@ public class ReportController {
     private final ReportService reportService;
 
     @PostMapping
+    @Operation(
+            description = "reportCase에는 REVIEW 또는 QUESTION 중에 하나를 넣어야 합니다."
+    )
     public RspTemplate<?> report(Principal principal,
                                  @RequestParam String reportCase,
                                  @RequestParam Long reportId,

--- a/bdink/src/main/java/com/app/bdink/report/controller/dto/request/ReportDto.java
+++ b/bdink/src/main/java/com/app/bdink/report/controller/dto/request/ReportDto.java
@@ -8,12 +8,4 @@ public record ReportDto(
 
         String reportReason
 ) {
-    public ReportReason toDomain(){
-        for(ReportReason a : ReportReason.values()){
-            if (a.equals(ReportReason.valueOf(reportReason))){
-                return a;
-            }
-        }
-        throw new CustomException(Error.NOT_FOUND_REPORT_TYPE, Error.NOT_FOUND_REPORT_TYPE.getMessage());
-    }
 }

--- a/bdink/src/main/java/com/app/bdink/report/controller/dto/response/ReportResponse.java
+++ b/bdink/src/main/java/com/app/bdink/report/controller/dto/response/ReportResponse.java
@@ -12,7 +12,7 @@ public record ReportResponse(
         return new ReportResponse(
                 report.getReportId(),
                 report.getReportCase().name(),
-                report.getReportReason().name()
+                report.getReportReason()
         );
     }
 }

--- a/bdink/src/main/java/com/app/bdink/report/domain/ReportReason.java
+++ b/bdink/src/main/java/com/app/bdink/report/domain/ReportReason.java
@@ -1,8 +1,12 @@
 package com.app.bdink.report.domain;
 
+import lombok.Getter;
+
+@Getter
 public enum ReportReason {
     ABUSIVE_CONTENT,
     ADVERTISEMENT,
     EXPLICIT_CONTENT,
-    OTHER
+    OTHER;
+
 }

--- a/bdink/src/main/java/com/app/bdink/report/entity/Report.java
+++ b/bdink/src/main/java/com/app/bdink/report/entity/Report.java
@@ -25,8 +25,7 @@ public class Report extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private ReportCase reportCase;
 
-    @Enumerated(EnumType.STRING)
-    private ReportReason reportReason;
+    private String reportReason;
 
     private Long reportId;
 
@@ -34,7 +33,7 @@ public class Report extends BaseTimeEntity {
     private Member member;
 
     @Builder
-    public Report(Member member, ReportCase reportCase, ReportReason reportReason, Long reportId) {
+    public Report(Member member, ReportCase reportCase, String reportReason, Long reportId) {
         this.member = member;
         this.reportCase = reportCase;
         this.reportId = reportId;

--- a/bdink/src/main/java/com/app/bdink/report/service/ReportService.java
+++ b/bdink/src/main/java/com/app/bdink/report/service/ReportService.java
@@ -47,7 +47,7 @@ public class ReportService {
         Report report = Report.builder()
                 .reportId(id)
                 .reportCase(ReportCase.valueOf(reportCase))
-                .reportReason(dto.toDomain())
+                .reportReason(dto.reportReason())
                 .member(member)
                 .build();
 


### PR DESCRIPTION
#193 
-----
관련 API : /api/v1/report

**문제 상황** : 
지금은 위 api request body의 reportReason가 문자열로 되어있으나 ABUSIVE_CONTENT, ADVERTISEMENT, EXPLICIT_CONTENT, OTHER 중 하나로 입력하지 않고 다른 문자열로 api를 호출하면 500이 내려오는 상황입니다.

**변경 사항** : 
ReportController post report api에서 RequestBody로 들어오는 reportReason를 enum 타입에서 string 타입으로 변경했습니다.