### PR TITLE
[Add] deleteBookmarkByClassRoomId API 구현

### DIFF
--- a/bdink/src/main/java/com/app/bdink/bookmark/adapter/in/controller/BookmarkController.java
+++ b/bdink/src/main/java/com/app/bdink/bookmark/adapter/in/controller/BookmarkController.java
@@ -15,12 +15,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.security.Principal;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -49,11 +44,20 @@ public class BookmarkController {
         return RspTemplate.success(Success.GET_BOOKMARK_SUCCESS,bookmarkService.getBookmarkClassRoom(member));
     }
 
-    @DeleteMapping
-    @Operation(method = "DELETE", description = "북마크를 삭제합니다.")
-    public RspTemplate<?> deleteBookmark(Principal principal, @RequestParam Long bookmarkId) {
+    @DeleteMapping("/{bookmarkId}")
+    @Operation(method = "DELETE", description = "북마크를 북마크 ID로 삭제합니다.")
+    public RspTemplate<?> deleteBookmark(Principal principal, @PathVariable Long bookmarkId) {
         Member member = memberService.findById(memberUtilService.getMemberId(principal));
         bookmarkService.deleteBookmark(member, bookmarkId);
+        return RspTemplate.success(Success.DELETE_BOOKMARK_SUCCESS,Success.DELETE_BOOKMARK_SUCCESS.getMessage());
+    }
+
+    @DeleteMapping("/classroom/{classRoomId}")
+    @Operation(method = "DELETE", description = "북마크를 클래스 ID로 삭제합니다.")
+    public RspTemplate<?> deleteBookmarkByClassRoomId(Principal principal, @PathVariable Long classRoomId) {
+        Member member = memberService.findById(memberUtilService.getMemberId(principal));
+        ClassRoomEntity classRoomEntity = classRoomService.findById(classRoomId);
+        bookmarkService.deleteBookmarkByClassRoomId(member, classRoomEntity);
         return RspTemplate.success(Success.DELETE_BOOKMARK_SUCCESS,Success.DELETE_BOOKMARK_SUCCESS.getMessage());
     }
 }

--- a/bdink/src/main/java/com/app/bdink/bookmark/repository/BookmarkRepository.java
+++ b/bdink/src/main/java/com/app/bdink/bookmark/repository/BookmarkRepository.java
@@ -10,4 +10,5 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     List<Bookmark> findByMember(Member member);
     int countByClassRoom(ClassRoomEntity classRoomEntity);
     boolean existsByClassRoomAndMember(ClassRoomEntity classRoomEntity, Member member);
+    void deleteByMemberAndClassRoom(Member member, ClassRoomEntity classRoomEntity);
 }

--- a/bdink/src/main/java/com/app/bdink/bookmark/repository/BookmarkRepository.java
+++ b/bdink/src/main/java/com/app/bdink/bookmark/repository/BookmarkRepository.java
@@ -4,11 +4,13 @@ import com.app.bdink.bookmark.entity.Bookmark;
 import com.app.bdink.classroom.adapter.out.persistence.entity.ClassRoomEntity;
 import com.app.bdink.member.entity.Member;
 import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     List<Bookmark> findByMember(Member member);
     int countByClassRoom(ClassRoomEntity classRoomEntity);
     boolean existsByClassRoomAndMember(ClassRoomEntity classRoomEntity, Member member);
-    void deleteByMemberAndClassRoom(Member member, ClassRoomEntity classRoomEntity);
+    Optional<Bookmark> findByClassRoomAndMember(ClassRoomEntity classRoomEntity, Member member);
 }

--- a/bdink/src/main/java/com/app/bdink/bookmark/service/BookmarkService.java
+++ b/bdink/src/main/java/com/app/bdink/bookmark/service/BookmarkService.java
@@ -8,6 +8,8 @@ import com.app.bdink.global.exception.CustomException;
 import com.app.bdink.global.exception.Error;
 import com.app.bdink.member.entity.Member;
 import java.util.List;
+import java.util.Optional;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -50,7 +52,13 @@ public class BookmarkService {
 
     @Transactional
     public void deleteBookmarkByClassRoomId(Member member, ClassRoomEntity classRoomEntity) {
-        bookmarkRepository.deleteByMemberAndClassRoom(member, classRoomEntity);
+        Optional<Bookmark> bookmark = bookmarkRepository.findByClassRoomAndMember(classRoomEntity, member);
+        if (bookmark.isEmpty()) {
+            throw new CustomException(Error.NOT_FOUND_BOOKMARK, Error.NOT_FOUND_BOOKMARK.getMessage());
+        } else if (!bookmark.get().getMember().equals(member)) {
+            throw new CustomException(Error.INVALID_USER_ACCESS, Error.INVALID_USER_ACCESS.getMessage());
+        }
+        bookmark.ifPresent(value -> bookmarkRepository.deleteById(value.getId()));
     }
 
     public long getBookmarkCountForClassRoom(ClassRoomEntity classRoomEntity) {

--- a/bdink/src/main/java/com/app/bdink/bookmark/service/BookmarkService.java
+++ b/bdink/src/main/java/com/app/bdink/bookmark/service/BookmarkService.java
@@ -48,8 +48,12 @@ public class BookmarkService {
         bookmarkRepository.deleteById(bookmarkId);
     }
 
+    @Transactional
+    public void deleteBookmarkByClassRoomId(Member member, ClassRoomEntity classRoomEntity) {
+        bookmarkRepository.deleteByMemberAndClassRoom(member, classRoomEntity);
+    }
+
     public long getBookmarkCountForClassRoom(ClassRoomEntity classRoomEntity) {
         return bookmarkRepository.countByClassRoom(classRoomEntity);
     }
-
 }

--- a/bdink/src/main/java/com/app/bdink/review/adapter/in/controller/ReviewController.java
+++ b/bdink/src/main/java/com/app/bdink/review/adapter/in/controller/ReviewController.java
@@ -1,5 +1,6 @@
 package com.app.bdink.review.adapter.in.controller;
 
+import com.app.bdink.member.util.MemberUtilService;
 import com.app.bdink.review.adapter.in.controller.dto.request.ReviewRequest;
 import com.app.bdink.classroom.adapter.out.persistence.entity.ClassRoomEntity;
 import com.app.bdink.classroom.service.ClassRoomService;
@@ -37,6 +38,7 @@ public class ReviewController {
     private final ReviewService reviewService;
     private final MemberService memberService;
     private final ClassRoomService classRoomService;
+    private final MemberUtilService memberUtilService;
 
     @Operation(method = "POST", description = "리뷰를 등록합니다.")
     @PostMapping
@@ -51,9 +53,10 @@ public class ReviewController {
 
     @Operation(method = "GET", description = "모든 리뷰를 조회합니다.")
     @GetMapping
-    public RspTemplate<List<ReviewResponse>> getAllReview(@RequestParam Long classRoomId, @PageableDefault(size = 8) Pageable pageable) {
+    public RspTemplate<List<ReviewResponse>> getAllReview(Principal principal, @RequestParam Long classRoomId, @PageableDefault(size = 8) Pageable pageable) {
         ClassRoomEntity classRoomEntity = classRoomService.findById(classRoomId);
-        return RspTemplate.success(Success.GET_REVIEW_SUCCESS, reviewService.getAllReview(classRoomEntity, pageable));
+        Member member = memberService.findById(memberUtilService.getMemberId(principal));
+        return RspTemplate.success(Success.GET_REVIEW_SUCCESS, reviewService.getAllReview(classRoomEntity, member, pageable));
     }
 
     @Operation(method = "PUT", description = "리뷰를 수정합니다.")

--- a/bdink/src/main/java/com/app/bdink/review/service/ReviewService.java
+++ b/bdink/src/main/java/com/app/bdink/review/service/ReviewService.java
@@ -49,14 +49,11 @@ public class ReviewService {
         return String.valueOf(reviewRepository.save(review).getId());
     }
 
-    public List<ReviewResponse> getAllReview(final ClassRoomEntity classRoomEntity, Pageable pageable) {
+    public List<ReviewResponse> getAllReview(final ClassRoomEntity classRoomEntity, final Member member, Pageable pageable) {
         Page<Review> reviews = reviewRepository.findAllByClassRoom(classRoomEntity, pageable);
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        String userId = authentication.getName();
-        Member currentMember = memberService.findById(Long.valueOf(userId));
         return reviews.stream()
                 .map(review -> {
-                    boolean isAuthor = review.getMember().getId().equals(currentMember.getId());
+                    boolean isAuthor = review.getMember().getId().equals(member.getId());
                     return ReviewResponse.from(review, isAuthor);
                 })
                 .toList();


### PR DESCRIPTION
## https://github.com/B-dink/B-dink-Server/issues/192 deleteBookmarkByClassRoomId API 구현

### 수정 사항 1.
<img width="509" alt="스크린샷 2025-05-10 오후 9 48 47" src="https://github.com/user-attachments/assets/3f200b79-1404-4968-97ce-842bf6c5bc8b" />

북마크를 북마크 ID로 삭제하는 기존 API를 남겨두고, 추가로 북마크를 클래스 ID로 삭제하는 API를 구현했습니다.
기존 북마크 ID로 삭제하던 API는 RequestParam으로 ID를 받았지만, 
동일한 경로의 북마크 API가 두 개 생기며 ID 입력 방식을 RequestParam에서 PathVariable로 수정했습니다.

### 수정 사항 2.
https://github.com/B-dink/B-dink-Server/pull/191
아래 코드는 위 피알에서 Authentication을 생성하고 이에 getName으로 해당 API 호출의 사용자 정보를 찾던 코드입니다.
```
Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
String userId = authentication.getName();
Member currentMember = memberService.findById(Long.valueOf(userId));
```
이 부분이 이미 Principal과 memberUtilService.getMemberId(principal)로 구현됨을 인지했고 이를 적용하는 방식으로 수정했습니다.