### PR TITLE
[Feat] Toss Payments Response 저장

### DIFF
--- a/bdink/src/main/java/com/app/bdink/global/exception/Error.java
+++ b/bdink/src/main/java/com/app/bdink/global/exception/Error.java
@@ -174,7 +174,8 @@ public enum Error {
     FAILED_METHOD_HANDLING_CANCEL(HttpStatus.INTERNAL_SERVER_ERROR, "취소 중 결제 시 사용한 결제 수단 처리과정에서 일시적인 오류가 발생했습니다."),
     FAILED_PARTIAL_REFUND(HttpStatus.INTERNAL_SERVER_ERROR, "은행 점검, 해약 계좌 등의 사유로 부분 환불이 실패했습니다."),
     FAILED_CLOSED_ACCOUNT_REFUND(HttpStatus.INTERNAL_SERVER_ERROR, "해약된 계좌로 인해 환불이 실패했습니다."),
-    COMMON_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요.")
+    COMMON_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요."),
+    PAYMENT_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "결제는 성공적으로 처리되었으나, 시스템에 주문 정보를 저장하는 과정에서 오류가 발생했습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/bdink/src/main/java/com/app/bdink/payment/entity/EssentialPayment.java
+++ b/bdink/src/main/java/com/app/bdink/payment/entity/EssentialPayment.java
@@ -1,0 +1,53 @@
+package com.app.bdink.payment.entity;
+
+import com.app.bdink.payment.controller.dto.PaymentResponse;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "essential_payment")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EssentialPayment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(length = 200, updatable = false)
+    private String paymentKey;
+
+    @Column(length = 64, updatable = false)
+    private String orderId;
+
+    private Integer totalAmount;
+
+    private String version;
+
+    private String mId;
+
+    private String requestedAt;
+
+    private String approvedAt;
+
+    @Column(length = 64)
+    private String lastTransactionKey;
+
+    public static EssentialPayment from(PaymentResponse response) {
+        EssentialPayment payment = new EssentialPayment();
+        payment.setPaymentKey(response.paymentKey());
+        payment.setOrderId(response.orderId());
+        payment.setTotalAmount(response.totalAmount());
+        payment.setVersion(response.version());
+        payment.setMId(response.mId());
+        payment.setRequestedAt(response.requestedAt());
+        payment.setApprovedAt(response.approvedAt());
+        payment.setLastTransactionKey(response.lastTransactionKey());
+        return payment;
+    }
+}

--- a/bdink/src/main/java/com/app/bdink/payment/repository/EssentialPaymentRepository.java
+++ b/bdink/src/main/java/com/app/bdink/payment/repository/EssentialPaymentRepository.java
@@ -1,0 +1,7 @@
+package com.app.bdink.payment.repository;
+
+import com.app.bdink.payment.entity.EssentialPayment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EssentialPaymentRepository extends JpaRepository<EssentialPayment, Long> {
+}

--- a/bdink/src/main/java/com/app/bdink/payment/repository/PaymentRepository.java
+++ b/bdink/src/main/java/com/app/bdink/payment/repository/PaymentRepository.java
@@ -1,7 +1,0 @@
-package com.app.bdink.payment.repository;
-
-import com.app.bdink.payment.entity.Payment;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface PaymentRepository extends JpaRepository<Payment, Long> {
-}

--- a/bdink/src/main/java/com/app/bdink/payment/service/PaymentService.java
+++ b/bdink/src/main/java/com/app/bdink/payment/service/PaymentService.java
@@ -11,14 +11,10 @@ import com.app.bdink.payment.repository.EssentialPaymentRepository;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.servlet.View;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -32,8 +28,6 @@ import reactor.core.scheduler.Schedulers;
 public class PaymentService {
 
     private final EssentialPaymentRepository essentialPaymentRepository;
-    private final View error;
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     private final String tossUrl = "https://api.tosspayments.com/v1/payments";
     //TODO: 테스트에서 나중에 사업자등록된거로 받기.


### PR DESCRIPTION
## #169 Toss Payments Response 저장
### 구현 사항
- Essential Payment Entity 구현 : 
결제 이후 해당 결제 정보를 다시 토스에 검색할 때 필요한 정보를 포함하고 있습니다.

- Essential Payment Entity 저장: 
PaymentService 클래스의 confirm 함수에서 토스페이먼츠 API를 통해 결제가 승인되면 반환되는 PaymentResponse 객체를 EssentialPayment 엔티티로 변환하여 데이터베이스에 저장합니다.
리액티브 프로그래밍 환경에서 JPA Repository(블로킹 방식)를 유지 사용하기 위해, Mono.fromCallable()과 subscribeOn(Schedulers.boundedElastic()) 패턴을 적용했습니다. 이 패턴은 블로킹 JPA 호출이 리액티브 애플리케이션의 이벤트 루프 스레드를 차단하지 않도록, 해당 작업을 별도의 스레드 풀에서 실행하게 합니다.
리액티브 Repository를 사용하는 방법도 고려했지만, R2DBC와 같은 추가적인 의존성을 추가해야 했기 때문에 위와 같은 방식으로 구현했습니다.

### 전달 사항
아직 paymentKey, orderId를 클라이언트 측으로부터 받지 못했습니다. 
내일 중으로 받을 수 있을 것 같아 결제 승인 테스트 이후 해당 PR에 수정 사항 반영하겠습니다.