### PR TITLE
[Feat] EssentialPayment와 Member 관계 수립 및 SignIn response 수정

### DIFF
--- a/bdink/src/main/java/com/app/bdink/oauth2/controller/SocialAuthController.java
+++ b/bdink/src/main/java/com/app/bdink/oauth2/controller/SocialAuthController.java
@@ -12,6 +12,7 @@ import com.app.bdink.member.controller.dto.response.NameCheckDto;
 import com.app.bdink.member.entity.Member;
 import com.app.bdink.member.service.MemberService;
 import com.app.bdink.member.util.MemberUtilService;
+import com.app.bdink.oauth2.controller.response.SignUpDto;
 import com.app.bdink.oauth2.domain.LoginResult;
 import com.app.bdink.oauth2.domain.RefreshToken;
 import com.app.bdink.oauth2.domain.TokenDto;
@@ -53,10 +54,11 @@ public class SocialAuthController {
     ) {
         LoginResult result = authService.signUpOrSignIn(provider, socialAccessToken);
         TokenDto tokenDto = tokenProvider.createToken(result.member());
+        SignUpDto signUpDto = new SignUpDto(tokenDto, result.member().getId());
         if (result.isNewMember()) {
-            return RspTemplate.success(Success.LOGIN_ACCEPTED, tokenDto);
+            return RspTemplate.success(Success.LOGIN_ACCEPTED, signUpDto);
         }
-        return RspTemplate.success(Success.SIGNUP_SUCCESS, tokenDto);
+        return RspTemplate.success(Success.SIGNUP_SUCCESS, signUpDto);
     }
 
     @DeleteMapping("/revoke")

--- a/bdink/src/main/java/com/app/bdink/oauth2/controller/response/SignUpDto.java
+++ b/bdink/src/main/java/com/app/bdink/oauth2/controller/response/SignUpDto.java
@@ -1,0 +1,8 @@
+package com.app.bdink.oauth2.controller.response;
+
+import com.app.bdink.oauth2.domain.TokenDto;
+
+public record SignUpDto(
+        TokenDto tokenDto,
+        Long memberId
+) {}

--- a/bdink/src/main/java/com/app/bdink/payment/controller/PaymentController.java
+++ b/bdink/src/main/java/com/app/bdink/payment/controller/PaymentController.java
@@ -1,6 +1,7 @@
 package com.app.bdink.payment.controller;
 
 import com.app.bdink.global.template.RspTemplate;
+import com.app.bdink.member.util.MemberUtilService;
 import com.app.bdink.payment.controller.dto.CancelRequest;
 import com.app.bdink.payment.controller.dto.ConfirmRequest;
 import com.app.bdink.payment.controller.dto.PaymentResponse;
@@ -20,13 +21,14 @@ import java.security.Principal;
 public class PaymentController {
 
     private final PaymentService paymentService;
+    private final MemberUtilService memberUtilService;
 
     @PostMapping("/confirm")
     @Operation(summary = "결제 승인", description = "토스페이먼츠 결제 승인을 처리합니다")
     public Mono<RspTemplate<PaymentResponse>> confirmPayment(
             Principal principal,
             @RequestBody ConfirmRequest confirmRequest) {
-        return paymentService.confirm(principal, confirmRequest);
+        return paymentService.confirm(memberUtilService.getMemberId(principal), confirmRequest);
     }
 
     @GetMapping("/{paymentKey}")

--- a/bdink/src/main/java/com/app/bdink/payment/controller/PaymentController.java
+++ b/bdink/src/main/java/com/app/bdink/payment/controller/PaymentController.java
@@ -11,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
 
+import java.security.Principal;
+
 @RestController
 @RequestMapping("/api/v1/payments")
 @RequiredArgsConstructor
@@ -22,8 +24,9 @@ public class PaymentController {
     @PostMapping("/confirm")
     @Operation(summary = "결제 승인", description = "토스페이먼츠 결제 승인을 처리합니다")
     public Mono<RspTemplate<PaymentResponse>> confirmPayment(
+            Principal principal,
             @RequestBody ConfirmRequest confirmRequest) {
-        return paymentService.confirm(confirmRequest);
+        return paymentService.confirm(principal, confirmRequest);
     }
 
     @GetMapping("/{paymentKey}")

--- a/bdink/src/main/java/com/app/bdink/payment/entity/EssentialPayment.java
+++ b/bdink/src/main/java/com/app/bdink/payment/entity/EssentialPayment.java
@@ -1,5 +1,6 @@
 package com.app.bdink.payment.entity;
 
+import com.app.bdink.member.entity.Member;
 import com.app.bdink.payment.controller.dto.PaymentResponse;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -27,6 +28,10 @@ public class EssentialPayment {
 
     private Integer totalAmount;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
     private String version;
 
     private String mId;
@@ -38,7 +43,7 @@ public class EssentialPayment {
     @Column(length = 64)
     private String lastTransactionKey;
 
-    public static EssentialPayment from(PaymentResponse response) {
+    public static EssentialPayment from(Member member, PaymentResponse response) {
         EssentialPayment payment = new EssentialPayment();
         payment.setPaymentKey(response.paymentKey());
         payment.setOrderId(response.orderId());
@@ -48,6 +53,7 @@ public class EssentialPayment {
         payment.setRequestedAt(response.requestedAt());
         payment.setApprovedAt(response.approvedAt());
         payment.setLastTransactionKey(response.lastTransactionKey());
+        payment.setMember(member);
         return payment;
     }
 }

--- a/bdink/src/main/java/com/app/bdink/payment/service/PaymentService.java
+++ b/bdink/src/main/java/com/app/bdink/payment/service/PaymentService.java
@@ -136,19 +136,4 @@ public class PaymentService {
                 RspTemplate.success(success, response)
         ).onErrorResume(Mono::error);
     }
-
-//    // 별도 메소드로 트랜잭션 처리 분리
-//    @Transactional
-//    public EssentialPayment savePaymentTransactionally(Principal principal, PaymentResponse response) {
-//        Member member = findMemberByPrinciple(principal);
-//        EssentialPayment payment = EssentialPayment.from(member, response);
-//        return essentialPaymentRepository.save(payment);
-//    }
-//
-//    private Member findMemberByPrinciple(Principal principal) {
-//        Long memberId = memberUtilService.getMemberId(principal);
-//        return memberRepository.findById(memberId).orElseThrow(
-//                () -> new NotFoundMemberException(Error.NOT_FOUND_USER_EXCEPTION, "해당 멤버를 찾지 못했습니다.")
-//        );
-//    }
 }

--- a/bdink/src/main/java/com/app/bdink/payment/service/PaymentService.java
+++ b/bdink/src/main/java/com/app/bdink/payment/service/PaymentService.java
@@ -33,7 +33,7 @@ public class PaymentService {
     private final TransactionalPaymentService transactionalPaymentService;
 
     public Mono<RspTemplate<PaymentResponse>> confirm(
-            Principal principal,
+            Long memberId,
             ConfirmRequest confirmRequest) throws PaymentFailedException {
         String authorizations = getBasicAuthHeader();
         WebClient webClient = WebClient.create(tossUrl);
@@ -50,7 +50,7 @@ public class PaymentService {
                 .bodyToMono(PaymentResponse.class)
                 .flatMap(response ->
                         Mono.fromCallable(() ->
-                                        transactionalPaymentService.savePaymentTransactional(principal, response)
+                                        transactionalPaymentService.savePaymentTransactional(memberId, response)
                                 )
                                 .subscribeOn(Schedulers.boundedElastic())
                                 .thenReturn(response)

--- a/bdink/src/main/java/com/app/bdink/payment/service/TransactionalPaymentService.java
+++ b/bdink/src/main/java/com/app/bdink/payment/service/TransactionalPaymentService.java
@@ -1,0 +1,39 @@
+package com.app.bdink.payment.service;
+
+import com.app.bdink.global.exception.Error;
+import com.app.bdink.member.entity.Member;
+import com.app.bdink.member.exception.NotFoundMemberException;
+import com.app.bdink.member.repository.MemberRepository;
+import com.app.bdink.member.util.MemberUtilService;
+import com.app.bdink.payment.controller.dto.PaymentResponse;
+import com.app.bdink.payment.entity.EssentialPayment;
+import com.app.bdink.payment.repository.EssentialPaymentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.Principal;
+
+@Service
+@RequiredArgsConstructor
+public class TransactionalPaymentService {
+
+    private final EssentialPaymentRepository essentialPaymentRepository;
+    private final MemberUtilService memberUtilService;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public EssentialPayment savePaymentTransactional(Principal principal, PaymentResponse response) {
+        Member member = findMemberByPrinciple(principal);
+        EssentialPayment payment = EssentialPayment.from(member, response);
+        return essentialPaymentRepository.save(payment);
+    }
+
+    @Transactional(readOnly = true)
+    public Member findMemberByPrinciple(Principal principal) {
+        Long memberId = memberUtilService.getMemberId(principal);
+        return memberRepository.findById(memberId).orElseThrow(
+                () -> new NotFoundMemberException(Error.NOT_FOUND_USER_EXCEPTION, "해당 멤버를 찾지 못했습니다.")
+        );
+    }
+}

--- a/bdink/src/main/java/com/app/bdink/payment/service/TransactionalPaymentService.java
+++ b/bdink/src/main/java/com/app/bdink/payment/service/TransactionalPaymentService.java
@@ -12,28 +12,19 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.security.Principal;
-
 @Service
 @RequiredArgsConstructor
 public class TransactionalPaymentService {
 
     private final EssentialPaymentRepository essentialPaymentRepository;
-    private final MemberUtilService memberUtilService;
     private final MemberRepository memberRepository;
 
     @Transactional
-    public EssentialPayment savePaymentTransactional(Principal principal, PaymentResponse response) {
-        Member member = findMemberByPrinciple(principal);
-        EssentialPayment payment = EssentialPayment.from(member, response);
-        return essentialPaymentRepository.save(payment);
-    }
-
-    @Transactional(readOnly = true)
-    public Member findMemberByPrinciple(Principal principal) {
-        Long memberId = memberUtilService.getMemberId(principal);
-        return memberRepository.findById(memberId).orElseThrow(
+    public EssentialPayment savePaymentTransactional(Long memberId, PaymentResponse response) {
+        Member member = memberRepository.findById(memberId).orElseThrow(
                 () -> new NotFoundMemberException(Error.NOT_FOUND_USER_EXCEPTION, "해당 멤버를 찾지 못했습니다.")
         );
+        EssentialPayment payment = EssentialPayment.from(member, response);
+        return essentialPaymentRepository.save(payment);
     }
 }


### PR DESCRIPTION
## #210 EssentialPayment와 Member 관계 수립
- EssentialPayment와 Member 관계 수립
결제 승인이 성공했을 때 저장되는 EssentialPayment 엔티티에 Member 인스턴스를 추가했습니다.
어떤 사용자의 결제 정보인지를 위해 추가했습니다.

## #212 SignIn response 수정
- SignIn response 수정
SignIn API에 response로 사용자 id를 추가하였습니다.