### PR TITLE
[Add] 강사별 클래스룸을 조회 API Response에 프로퍼티 추가

### DIFF
--- a/bdink/src/main/java/com/app/bdink/classroom/service/ClassRoomService.java
+++ b/bdink/src/main/java/com/app/bdink/classroom/service/ClassRoomService.java
@@ -19,6 +19,7 @@ import com.app.bdink.external.kollus.entity.KollusMediaLink;
 import com.app.bdink.external.kollus.repository.KollusMediaLinkRepository;
 import com.app.bdink.global.exception.CustomException;
 import com.app.bdink.global.exception.Error;
+import com.app.bdink.instructor.adapter.in.controller.dto.response.InstructorClassroomDto;
 import com.app.bdink.instructor.adapter.out.persistence.entity.Instructor;
 import com.app.bdink.instructor.mapper.InstructorMapper;
 import com.app.bdink.lecture.entity.Lecture;
@@ -163,9 +164,9 @@ public class ClassRoomService implements ClassRoomUseCase {
     }
 
     @Transactional(readOnly = true)
-    public List<CareerClassroomDto> getFilteredClassroomByInstructor(final Instructor instructor) {
+    public List<InstructorClassroomDto> getFilteredClassroomByInstructor(Member member, final Instructor instructor) {
         return classRoomRepository.findAllByInstructor(instructor).stream()
-                .map(classRoom -> CareerClassroomDto.of(classRoom, getChapterSummary(classRoom.getId()), reviewService.countReview(classRoom)))
+                .map(classRoom -> InstructorClassroomDto.of(classRoom, member, getChapterSummary(classRoom.getId()), reviewService.countReview(classRoom)))
                 .toList();
     }
 

--- a/bdink/src/main/java/com/app/bdink/instructor/adapter/in/controller/InstructorController.java
+++ b/bdink/src/main/java/com/app/bdink/instructor/adapter/in/controller/InstructorController.java
@@ -7,6 +7,7 @@ import com.app.bdink.classroom.domain.Career;
 import com.app.bdink.classroom.service.ClassRoomService;
 import com.app.bdink.common.util.CreateIdDto;
 import com.app.bdink.external.aws.service.S3Service;
+import com.app.bdink.instructor.adapter.in.controller.dto.response.InstructorClassroomDto;
 import com.app.bdink.instructor.adapter.out.persistence.entity.Instructor;
 import com.app.bdink.instructor.util.InstructorUtilService;
 import com.app.bdink.member.util.MemberUtilService;
@@ -22,6 +23,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -96,9 +98,10 @@ public class InstructorController {
 
     @GetMapping("/{id}/classroom")
     @Operation(method = "GET", description = "강사별 클래스룸을 조회합니다.")
-    public RspTemplate<List<CareerClassroomDto>> getClassRoomByInstructor(@PathVariable Long id){
+    public RspTemplate<List<InstructorClassroomDto>> getClassRoomByInstructor(Principal principal, @PathVariable Long id){
         Instructor instructor = instructorService.findById(id);
-        List<CareerClassroomDto> classRoomEntityList = classRoomService.getFilteredClassroomByInstructor(instructor);
+        Member member = memberService.findById(memberUtilService.getMemberId(principal));
+        List<InstructorClassroomDto> classRoomEntityList = classRoomService.getFilteredClassroomByInstructor(member, instructor);
         return RspTemplate.success(Success.GET_CLASSROOM_FILTERED_INSTURCTOR_SUCCESS, classRoomEntityList);
     }
 

--- a/bdink/src/main/java/com/app/bdink/instructor/adapter/in/controller/dto/response/InstructorClassroomDto.java
+++ b/bdink/src/main/java/com/app/bdink/instructor/adapter/in/controller/dto/response/InstructorClassroomDto.java
@@ -1,29 +1,37 @@
-package com.app.bdink.classroom.adapter.in.controller.dto.response;
+package com.app.bdink.instructor.adapter.in.controller.dto.response;
 
 import com.app.bdink.chapter.domain.ChapterSummary;
 import com.app.bdink.classroom.adapter.out.persistence.entity.ClassRoomEntity;
 import com.app.bdink.classroom.domain.Career;
+import com.app.bdink.member.entity.Member;
 import com.app.bdink.price.domain.PriceDetail;
 
-public record CareerClassroomDto(
+public record InstructorClassroomDto(
         Long id,
         Career career,
         String title,
         String classRoomThumbnail,
         String instructor,
         PriceDetail priceDetail,
+        String marketingImage,
+        String marketingText,
+        String marketingSites,
 
         int totalLectureCount,
         int totalReviewCount
 ) {
-    public static CareerClassroomDto of(final ClassRoomEntity classRoomEntity, final ChapterSummary chapterSummary, int totalReviewCount){
-        return new CareerClassroomDto(
+    public static InstructorClassroomDto of(
+            final ClassRoomEntity classRoomEntity, final Member member, final ChapterSummary chapterSummary, int totalReviewCount){
+        return new InstructorClassroomDto(
                 classRoomEntity.getId(),
                 classRoomEntity.getCareer(),
                 classRoomEntity.getTitle(),
                 classRoomEntity.getThumbnail(),
                 classRoomEntity.getInstructor().getMember().getName(),
                 classRoomEntity.getPriceDetail(),
+                member.getInstructor().getMarketingImage(),
+                member.getInstructor().getMarketingText(),
+                member.getInstructor().getMarketingSites(),
                 chapterSummary.getTotalLectureCount(),
                 totalReviewCount
         );


### PR DESCRIPTION
## #206 강사별 클래스룸을 조회 API Response 수정

해당 API : 강사별 클래스룸을 조회 API - /instructor/{id}/classroom

강사별 클래스룸을 조회 API Response에 String marketingImage, String marketingText, String marketingSites 프로퍼티 추가했습니다. 이때 InstructorClassroomDto를 따로 구현했습니다. 아래는 기존 Response DTO 입니다.

<img width="598" alt="스크린샷 2025-05-17 오후 4 41 17" src="https://github.com/user-attachments/assets/b011f575-76a4-4190-95ee-648696ba2689" />

기존 Response DTO에 marketingImage, marketingText, marketingSites 프로퍼티 추가 요청에 따라 아래와 같이 추가했습니다.

<img width="586" alt="스크린샷 2025-05-17 오후 4 43 23" src="https://github.com/user-attachments/assets/f3873cb9-6be0-41f7-91a0-35dd09362548" />
