### PR TITLE
[Refactor] 유튜브 비디오 개별 조회 API 응답에 값 추가

### DIFF
--- a/bdink/src/main/java/com/app/bdink/youtube/domain/YoutubeInfoDto.java
+++ b/bdink/src/main/java/com/app/bdink/youtube/domain/YoutubeInfoDto.java
@@ -2,9 +2,10 @@ package com.app.bdink.youtube.domain;
 
 public record YoutubeInfoDto(
         String youtubeVideoUrl,
-        YoutubeType youtubeType
+        YoutubeType youtubeType,
+        Long instructorId
 ) {
-    public static YoutubeInfoDto of(final String youtubeVideoUrl, final YoutubeType youtubeType) {
-        return new YoutubeInfoDto(youtubeVideoUrl, youtubeType);
+    public static YoutubeInfoDto of(final String youtubeVideoUrl, final YoutubeType youtubeType, final Long instructorId) {
+        return new YoutubeInfoDto(youtubeVideoUrl, youtubeType, instructorId);
     }
 }

--- a/bdink/src/main/java/com/app/bdink/youtube/entity/Youtube.java
+++ b/bdink/src/main/java/com/app/bdink/youtube/entity/Youtube.java
@@ -27,7 +27,7 @@ public class Youtube {
     private Instructor instructor;
 
     @Builder
-    public Youtube(String youtubeVideoLink, YoutubeType youtubeType) {
+    public Youtube(String youtubeVideoLink, YoutubeType youtubeType, Instructor instructor) {
         this.youtubeVideoLink = youtubeVideoLink;
         this.youtubeType = youtubeType;
     }

--- a/bdink/src/main/java/com/app/bdink/youtube/entity/Youtube.java
+++ b/bdink/src/main/java/com/app/bdink/youtube/entity/Youtube.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "Youtube")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Youtube {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false)
@@ -23,13 +24,14 @@ public class Youtube {
     @Enumerated(EnumType.STRING)
     private YoutubeType youtubeType;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     private Instructor instructor;
 
     @Builder
     public Youtube(String youtubeVideoLink, YoutubeType youtubeType, Instructor instructor) {
         this.youtubeVideoLink = youtubeVideoLink;
         this.youtubeType = youtubeType;
+        this.instructor = instructor;
     }
 
     public void updateYoutubeVideoLink(String youtubeVideoLink) {

--- a/bdink/src/main/java/com/app/bdink/youtube/entity/Youtube.java
+++ b/bdink/src/main/java/com/app/bdink/youtube/entity/Youtube.java
@@ -1,5 +1,6 @@
 package com.app.bdink.youtube.entity;
 
+import com.app.bdink.instructor.adapter.out.persistence.entity.Instructor;
 import com.app.bdink.youtube.domain.YoutubeType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -21,6 +22,9 @@ public class Youtube {
 
     @Enumerated(EnumType.STRING)
     private YoutubeType youtubeType;
+
+    @OneToOne
+    private Instructor instructor;
 
     @Builder
     public Youtube(String youtubeVideoLink, YoutubeType youtubeType) {

--- a/bdink/src/main/java/com/app/bdink/youtube/service/YoutubeService.java
+++ b/bdink/src/main/java/com/app/bdink/youtube/service/YoutubeService.java
@@ -30,7 +30,7 @@ public class YoutubeService {
     @Transactional(readOnly = true)
     public YoutubeInfoDto getYoutubeInfoDto(Long youtubeId) {
         Youtube youtubeVideo = findById(youtubeId);
-        return YoutubeInfoDto.of(youtubeVideo.getYoutubeVideoLink(), youtubeVideo.getYoutubeType());
+        return YoutubeInfoDto.of(youtubeVideo.getYoutubeVideoLink(), youtubeVideo.getYoutubeType(), youtubeVideo.getInstructor().getId());
     }
 
     @Transactional

--- a/bdink/src/main/java/com/app/bdink/youtube/service/YoutubeService.java
+++ b/bdink/src/main/java/com/app/bdink/youtube/service/YoutubeService.java
@@ -2,6 +2,8 @@ package com.app.bdink.youtube.service;
 
 import com.app.bdink.global.exception.CustomException;
 import com.app.bdink.global.exception.Error;
+import com.app.bdink.instructor.adapter.out.persistence.entity.Instructor;
+import com.app.bdink.instructor.repository.InstructorRepository;
 import com.app.bdink.youtube.domain.YoutubeInfoDto;
 import com.app.bdink.youtube.domain.YoutubeType;
 import com.app.bdink.youtube.entity.Youtube;
@@ -16,6 +18,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class YoutubeService {
     private final YoutubeRepository youtubeRepository;
+    private final InstructorRepository instructorRepository;
 
     public Youtube findById(Long id) {
         return youtubeRepository.findById(id).orElseThrow(
@@ -38,6 +41,7 @@ public class YoutubeService {
         Youtube youtube = Youtube.builder()
                 .youtubeVideoLink(youtubeInfoDto.youtubeVideoUrl())
                 .youtubeType(youtubeInfoDto.youtubeType())
+                .instructor(findInstructorById(youtubeInfoDto.instructorId()))
                 .build();
         youtubeRepository.save(youtube);
         return String.valueOf(youtube.getId());
@@ -50,5 +54,11 @@ public class YoutubeService {
 
     public void deleteYoutubeVideo(Youtube youtube) {
         youtubeRepository.delete(youtube);
+    }
+
+    private Instructor findInstructorById(Long instructorId) {
+        return instructorRepository.findById(instructorId).orElseThrow(
+                () -> new CustomException(Error.NOT_FOUND_INSTRUCTOR, Error.NOT_FOUND_INSTRUCTOR.getMessage())
+        );
     }
 }

--- a/bdink/src/main/java/com/app/bdink/youtube/service/YoutubeService.java
+++ b/bdink/src/main/java/com/app/bdink/youtube/service/YoutubeService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -33,7 +34,10 @@ public class YoutubeService {
     @Transactional(readOnly = true)
     public YoutubeInfoDto getYoutubeInfoDto(Long youtubeId) {
         Youtube youtubeVideo = findById(youtubeId);
-        return YoutubeInfoDto.of(youtubeVideo.getYoutubeVideoLink(), youtubeVideo.getYoutubeType(), youtubeVideo.getInstructor().getId());
+        Long instructorId = Optional.ofNullable(youtubeVideo.getInstructor())
+                .map(Instructor::getId)
+                .orElse(null);
+        return YoutubeInfoDto.of(youtubeVideo.getYoutubeVideoLink(), youtubeVideo.getYoutubeType(), instructorId);
     }
 
     @Transactional


### PR DESCRIPTION
## #222 유튜브 비디오 개별 조회 API 응답에 instructorId 추가

- Youtube 엔티티에 Instructor 연관관계 @OneToOne으로 추가
- 유튜브 비디오 생성 API Request Body에 instructorId 추가
- 유튜브 비디오 개별 조회 API Response Body에 instructorId 추가
- 유튜브 비디오 카테고리별 조회 API Response Body에 instructorId 추가