### PR TITLE
[Modify] 소셜 로그인 성공시 응답 코드 변경

### DIFF
--- a/bdink/src/main/java/com/app/bdink/oauth2/apple/service/AppleSignInService.java
+++ b/bdink/src/main/java/com/app/bdink/oauth2/apple/service/AppleSignInService.java
@@ -55,6 +55,7 @@ public class AppleSignInService {
     private final MemberRepository memberRepository;
 
     public LoginResult getAppleId(String identityToken) {
+        log.info("getAppleId: {}", identityToken);
         Map<String, String> headers = appleJwtParser.parseHeaders(identityToken);
 
         ResponseEntity<ApplePublicKeys> result = restClient.get()
@@ -70,6 +71,7 @@ public class AppleSignInService {
         Optional<Member> member = getByAppleId(appleId);
 
         if (member.isEmpty()){
+            log.info("apple id {} not found", appleId);
             member = Optional.of(memberRepository.save(
                     Member.builder()
                             .name("버딩크 유저"+ UUID.randomUUID())
@@ -80,9 +82,10 @@ public class AppleSignInService {
                             .socialType(SocialType.APPLE)
                             .role(Role.SIGNUP_PROGRESS)
                             .build()));
-            return LoginResult.from(member.get(), false);
+            return LoginResult.from(member.get(), true);
         }
-        return LoginResult.from(member.get(), true);
+        log.info("apple id {} found", appleId);
+        return LoginResult.from(member.get(), false);
     }
 
     @Transactional(readOnly = true)

--- a/bdink/src/main/java/com/app/bdink/oauth2/apple/service/AppleSignInService.java
+++ b/bdink/src/main/java/com/app/bdink/oauth2/apple/service/AppleSignInService.java
@@ -55,7 +55,6 @@ public class AppleSignInService {
     private final MemberRepository memberRepository;
 
     public LoginResult getAppleId(String identityToken) {
-        log.info("getAppleId: {}", identityToken);
         Map<String, String> headers = appleJwtParser.parseHeaders(identityToken);
 
         ResponseEntity<ApplePublicKeys> result = restClient.get()
@@ -71,7 +70,6 @@ public class AppleSignInService {
         Optional<Member> member = getByAppleId(appleId);
 
         if (member.isEmpty()){
-            log.info("apple id {} not found", appleId);
             member = Optional.of(memberRepository.save(
                     Member.builder()
                             .name("버딩크 유저"+ UUID.randomUUID())
@@ -84,7 +82,6 @@ public class AppleSignInService {
                             .build()));
             return LoginResult.from(member.get(), true);
         }
-        log.info("apple id {} found", appleId);
         return LoginResult.from(member.get(), false);
     }
 

--- a/bdink/src/main/java/com/app/bdink/oauth2/kakao/service/KakaoSignInService.java
+++ b/bdink/src/main/java/com/app/bdink/oauth2/kakao/service/KakaoSignInService.java
@@ -93,8 +93,6 @@ public class KakaoSignInService {
         }
 
         return new LoginResult(member.get(), false);
-
-
     }
 
     public void revokeMember(final Member member) {


### PR DESCRIPTION
## #248 소셜 로그인 성공시 응답 코드 변경
- AppleSignInService의 getAppleId에서 isNewMember를 리턴하며 
새로운 소셜 로그인 유저의 경우 자체 회원가입을 위해 202를 내려주고, 이전에 이미 회원가입했던 사용자가 로그아웃 이후 다시 로그인한 경우 201을 내려주도록 합니다.
하지만 기존에는 새로운 유저일 때 isNewMember가 false로 설정되어 있어 응답 코드가 반대로 내려갔던 것이고 수정했습니다.
