### PR TITLE
[Modify] 클래스룸 챕터 조회 api 500 에러 자세한 에러 처리 추가

### DIFF
--- a/bdink/src/main/java/com/app/bdink/classroom/service/ClassRoomService.java
+++ b/bdink/src/main/java/com/app/bdink/classroom/service/ClassRoomService.java
@@ -119,9 +119,10 @@ public class ClassRoomService implements ClassRoomUseCase {
                 .setScale(2, RoundingMode.HALF_UP)
                 .doubleValue();
 
-        Optional<Sugang> sugangOPT = sugangRepository.findByMemberAndClassRoomEntity(member, classRoomEntity);
+        Sugang sugang = sugangRepository.findByMemberAndClassRoomEntity(member, classRoomEntity).orElseThrow(() ->
+                new CustomException(Error.NOT_FOUND_SUGANGLIST, Error.NOT_FOUND_SUGANGLIST.getMessage()));
 
-        LocalDate expiredDate = sugangOPT.get().getExpiredDate();
+        LocalDate expiredDate = sugang.getExpiredDate();
 
         return ChapterListResponse.of(totalProgress, totalLectures, completedLectures, expiredDate, chapters);
     }

--- a/bdink/src/main/java/com/app/bdink/global/exception/Error.java
+++ b/bdink/src/main/java/com/app/bdink/global/exception/Error.java
@@ -22,6 +22,7 @@ public enum Error {
     NOT_FOUND_ANSWER(HttpStatus.NOT_FOUND, "찾을 수 없는 답변입니다."),
     NOT_FOUND_BOOKMARK(HttpStatus.NOT_FOUND, "찾을 수 없는 북마크입니다."),
     NOT_FOUND_SUGANG(HttpStatus.NOT_FOUND, "찾을 수 없는 수강입니다."),
+    NOT_FOUND_SUGANGLIST(HttpStatus.NOT_FOUND, "수강 신청이 되어있지 않은 유저입니다."),
 
     NOT_FOUND_REVIEW(HttpStatus.NOT_FOUND, "찾을 수 없는 리뷰입니다."),
     NOT_FOUND_SCHEDULE(HttpStatus.NOT_FOUND, "찾을 수 없는 일정입니다."),


### PR DESCRIPTION
## 관련 이슈
#265 

## 관련 내용
- [결제 -> 수강 post api 호출] 이 일련의 과정이 되어있지 않은 유저일경우 500에러가 터지는 것을 확인
- Error Status 404 반환 및 수강 신청이 되어있지 않다는 메시지 추가