### PR TITLE
[Modify] 클래스룸 디테일 페이지 조회 API에 응답 데이터 추가, 챕터마다 썸네일 페이지 데이터 추가

### DIFF
--- a/bdink/src/main/java/com/app/bdink/chapter/entity/Chapter.java
+++ b/bdink/src/main/java/com/app/bdink/chapter/entity/Chapter.java
@@ -29,14 +29,17 @@ public class Chapter extends BaseTimeEntity {
 
     private String title; // 챕터 제목
 
+    private String thumbnail; //챕터당 필요한 썸네일
+
     // TODO: lectureCount 필드는 사용하지 않는 것으로 보입니다. 제거해도 될 것 같습니다.
     private int lectureCount; // 해당 챕터에 속한 강좌의 수
 
     private int number;
 
-    public Chapter(ClassRoomEntity classRoomEntity, String title) {
+    public Chapter(ClassRoomEntity classRoomEntity, String title, String thumbnail) {
         this.classRoom = classRoomEntity;
         this.title = title;
+        this.thumbnail = thumbnail;
         this.lectureCount = 0;
         this.number = 1;
     }

--- a/bdink/src/main/java/com/app/bdink/chapter/service/ChapterService.java
+++ b/bdink/src/main/java/com/app/bdink/chapter/service/ChapterService.java
@@ -28,8 +28,8 @@ public class ChapterService {
 
 
 
-    public String createChapter(final ClassRoomEntity classRoomEntity, final String title){
-        Chapter chapter = new Chapter(classRoomEntity, title);
+    public String createChapter(final ClassRoomEntity classRoomEntity, final String title, final String thumbnail){
+        Chapter chapter = new Chapter(classRoomEntity, title, thumbnail);
         boolean isNotFirstChapter = chapterRepository.existsByClassRoom(classRoomEntity);
 
         if (isNotFirstChapter){ //첫번째 챕터아니면 ++

--- a/bdink/src/main/java/com/app/bdink/classroom/adapter/in/controller/dto/response/ClassRoomDetailChapterResponse.java
+++ b/bdink/src/main/java/com/app/bdink/classroom/adapter/in/controller/dto/response/ClassRoomDetailChapterResponse.java
@@ -1,8 +1,20 @@
 package com.app.bdink.classroom.adapter.in.controller.dto.response;
 
-public record ClassRoomDetailChapterResponse (
+import com.app.bdink.chapter.entity.Chapter;
+import com.app.bdink.lecture.controller.dto.response.LectureDetailResponse;
 
+import java.util.List;
+
+public record ClassRoomDetailChapterResponse (
+    String chapterThumbnail,
+    String title,
+    List<LectureDetailResponse> lectureDetailResponses
 )
 
 {
+    public static ClassRoomDetailChapterResponse from(final Chapter chapter, List<LectureDetailResponse> lectureDetailResponses) {
+        return new ClassRoomDetailChapterResponse (
+                chapter.getThumbnail(), chapter.getTitle(), lectureDetailResponses
+        );
+    }
 }

--- a/bdink/src/main/java/com/app/bdink/classroom/adapter/in/controller/dto/response/ClassRoomDetailChapterResponse.java
+++ b/bdink/src/main/java/com/app/bdink/classroom/adapter/in/controller/dto/response/ClassRoomDetailChapterResponse.java
@@ -1,0 +1,8 @@
+package com.app.bdink.classroom.adapter.in.controller.dto.response;
+
+public record ClassRoomDetailChapterResponse (
+
+)
+
+{
+}

--- a/bdink/src/main/java/com/app/bdink/classroom/adapter/in/controller/dto/response/ClassRoomDetailResponse.java
+++ b/bdink/src/main/java/com/app/bdink/classroom/adapter/in/controller/dto/response/ClassRoomDetailResponse.java
@@ -21,6 +21,8 @@ public record ClassRoomDetailResponse(
         Level level,
         Boolean isBookmarked,
 
-        List<String> detailPageImageUrls
+        List<String> detailPageImageUrls,
+
+        List<ClassRoomDetailChapterResponse> chapters
 ) {
 }

--- a/bdink/src/main/java/com/app/bdink/classroom/adapter/in/controller/dto/response/ClassRoomDetailResponse.java
+++ b/bdink/src/main/java/com/app/bdink/classroom/adapter/in/controller/dto/response/ClassRoomDetailResponse.java
@@ -15,7 +15,7 @@ public record ClassRoomDetailResponse(
 
         String thumbnail,
 
-        Boolean payment,
+        boolean payment,
 
         PriceDetail priceDetail,
         Level level,

--- a/bdink/src/main/java/com/app/bdink/classroom/service/ClassRoomService.java
+++ b/bdink/src/main/java/com/app/bdink/classroom/service/ClassRoomService.java
@@ -22,6 +22,7 @@ import com.app.bdink.global.exception.Error;
 import com.app.bdink.instructor.adapter.in.controller.dto.response.InstructorClassroomDto;
 import com.app.bdink.instructor.adapter.out.persistence.entity.Instructor;
 import com.app.bdink.instructor.mapper.InstructorMapper;
+import com.app.bdink.lecture.controller.dto.response.LectureDetailResponse;
 import com.app.bdink.lecture.entity.Lecture;
 import com.app.bdink.lecture.repository.LectureRepository;
 import com.app.bdink.lecture.service.LectureService;
@@ -220,7 +221,7 @@ public class ClassRoomService implements ClassRoomUseCase {
 
         Optional<Sugang> sugangOpt = sugangRepository.findByMemberAndClassRoomEntity(member, classRoomEntity);
 
-        Boolean payment = false;
+        boolean payment = false;
 
         if(sugangOpt.isPresent()){
             Sugang sugang = sugangOpt.get();
@@ -238,6 +239,15 @@ public class ClassRoomService implements ClassRoomUseCase {
                 .map(ClassRoomDetailImage::getImageUrl)
                 .toList();
 
+        List<ClassRoomDetailChapterResponse> chapters = classRoomEntity.getChapters().stream()
+                .map(chapter -> {
+                    List<LectureDetailResponse> lectureDetailResponses = chapter.getLectures().stream()
+                            .map(LectureDetailResponse::from)
+                            .collect(Collectors.toList());
+                    return ClassRoomDetailChapterResponse.from(chapter, lectureDetailResponses);
+                })
+                .collect(Collectors.toList());
+
         return new ClassRoomDetailResponse(
                 classRoomEntity.getTitle(),
                 classRoomEntity.getIntroduction(),
@@ -249,7 +259,8 @@ public class ClassRoomService implements ClassRoomUseCase {
                 classRoomEntity.getPriceDetail(),
                 classRoomEntity.getLevel(),
                 isBookmarked,
-                imageUrls
+                imageUrls,
+                chapters
         );
     }
 

--- a/bdink/src/main/java/com/app/bdink/lecture/controller/dto/response/LectureDetailResponse.java
+++ b/bdink/src/main/java/com/app/bdink/lecture/controller/dto/response/LectureDetailResponse.java
@@ -1,0 +1,14 @@
+package com.app.bdink.lecture.controller.dto.response;
+
+import com.app.bdink.lecture.entity.Lecture;
+
+public record LectureDetailResponse(
+        Long lectureId,
+        String lectureTitle,
+        String lectureTime
+) {
+    public static LectureDetailResponse from(final Lecture lecture) {
+        return new LectureDetailResponse(lecture.getId(), lecture.getTitle(), lecture.getTime().toString());
+    }
+}
+

--- a/bdink/src/main/java/com/app/bdink/lecture/repository/LectureRepository.java
+++ b/bdink/src/main/java/com/app/bdink/lecture/repository/LectureRepository.java
@@ -2,12 +2,9 @@ package com.app.bdink.lecture.repository;
 
 import com.app.bdink.classroom.adapter.out.persistence.entity.ClassRoomEntity;
 import com.app.bdink.lecture.entity.Lecture;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface LectureRepository extends JpaRepository<Lecture, Long> {
     int countByClassRoom(ClassRoomEntity classRoomEntity);


### PR DESCRIPTION
## 관련 이슈
- #273 

## 관련 내용
- 기존 api/v1/classroom/chapter 에 있던 정보중 진행률을 뺀 정보 추가
- 챕터당 썸네일 이미지 데이터 추가

## 추가된 응답 데이터
- chapterThumbnail
- title (chapter)
- lectureDetailResponses
  - lectureId
  - lectureTitle
  - lectureTime