### PR TITLE
[Modify] 클래스룸 디테일 페이지 조회 API 응답 데이터 추가 (챕터, 자막, 강의 수)

### DIFF
--- a/bdink/src/main/java/com/app/bdink/classroom/adapter/in/controller/dto/request/ClassRoomDto.java
+++ b/bdink/src/main/java/com/app/bdink/classroom/adapter/in/controller/dto/request/ClassRoomDto.java
@@ -8,6 +8,7 @@ public record ClassRoomDto(
         String title,
 
         String introduction,
+        String subtitles,
         PriceDto priceDto,
         Level level,
         Career career

--- a/bdink/src/main/java/com/app/bdink/classroom/adapter/in/controller/dto/response/ClassRoomDetailResponse.java
+++ b/bdink/src/main/java/com/app/bdink/classroom/adapter/in/controller/dto/response/ClassRoomDetailResponse.java
@@ -17,6 +17,7 @@ public record ClassRoomDetailResponse(
         Integer totalLectureCount,
         LocalDate expiredDate,
         String totalLectureTime,
+        String subtitles,
 
         String thumbnail,
 

--- a/bdink/src/main/java/com/app/bdink/classroom/adapter/in/controller/dto/response/ClassRoomDetailResponse.java
+++ b/bdink/src/main/java/com/app/bdink/classroom/adapter/in/controller/dto/response/ClassRoomDetailResponse.java
@@ -3,6 +3,7 @@ package com.app.bdink.classroom.adapter.in.controller.dto.response;
 import com.app.bdink.classroom.domain.Level;
 import com.app.bdink.price.domain.PriceDetail;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public record ClassRoomDetailResponse(
@@ -10,8 +11,12 @@ public record ClassRoomDetailResponse(
         String introduction,
         long bookmarkCount,
         String instructor,
-
         String instructorProfile,
+
+        Integer totalChapterCount,
+        Integer totalLectureCount,
+        LocalDate expiredDate,
+        String totalLectureTime,
 
         String thumbnail,
 

--- a/bdink/src/main/java/com/app/bdink/classroom/adapter/out/persistence/entity/ClassRoomEntity.java
+++ b/bdink/src/main/java/com/app/bdink/classroom/adapter/out/persistence/entity/ClassRoomEntity.java
@@ -55,12 +55,16 @@ public class ClassRoomEntity extends BaseTimeEntity {
     @Embedded
     private PriceDetail priceDetail;
 
+    @Column(nullable = false)
+    private String subtitles;
+
     @OneToMany(mappedBy = "classRoom", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ClassRoomDetailImage> detailPageImages = new ArrayList<>();
 
     @Builder
     public ClassRoomEntity(final String title, final String introduction,
                            final String thumbnail, final String introLink,
+                           final String subtitles,
                            final Instructor instructor, final PriceDetail priceDetail, final Level level, final Career career) {
 
         this.title = title;
@@ -69,6 +73,7 @@ public class ClassRoomEntity extends BaseTimeEntity {
         this.introduction = introduction;
         this.priceDetail = priceDetail;
         this.introLink = introLink;
+        this.subtitles = subtitles;
         this.level = level;
         this.career = career;
     }

--- a/bdink/src/main/java/com/app/bdink/classroom/service/ClassRoomService.java
+++ b/bdink/src/main/java/com/app/bdink/classroom/service/ClassRoomService.java
@@ -224,13 +224,17 @@ public class ClassRoomService implements ClassRoomUseCase {
 
         boolean payment = false;
 
+        Sugang sugang = null;
+
         if(sugangOpt.isPresent()){
-            Sugang sugang = sugangOpt.get();
+            sugang = sugangOpt.get();
             if (sugang.getSugangStatus() == SugangStatus.PAYMENT_COMPLETED) {
                 log.info("해당 클래스에 대해 결제 완료된 유저입니다.");
                 payment = true;
             }
         }
+
+        LocalDate expiredDate = sugang != null ? sugang.getExpiredDate() : null;
 
 
         //클래스룸 엔티티로 디테일이미지 리스트를 가져옴.
@@ -257,8 +261,9 @@ public class ClassRoomService implements ClassRoomUseCase {
                 classRoomEntity.getInstructor().getMember().getPictureUrl(),
                 chapterRepository.countByClassRoom(classRoomEntity),
                 lectureRepository.countByClassRoom(classRoomEntity),
-                sugangOpt.get().getExpiredDate(),
+                expiredDate,
                 getTotalTimeFormatted(classRoomEntity.getId()),
+                classRoomEntity.getSubtitles(),
                 classRoomEntity.getThumbnail(),
                 payment,
                 classRoomEntity.getPriceDetail(),

--- a/bdink/src/main/java/com/app/bdink/classroom/service/ClassRoomService.java
+++ b/bdink/src/main/java/com/app/bdink/classroom/service/ClassRoomService.java
@@ -19,6 +19,7 @@ import com.app.bdink.external.kollus.entity.KollusMediaLink;
 import com.app.bdink.external.kollus.repository.KollusMediaLinkRepository;
 import com.app.bdink.global.exception.CustomException;
 import com.app.bdink.global.exception.Error;
+import com.app.bdink.global.totalTime.TotalTimeUtil;
 import com.app.bdink.instructor.adapter.in.controller.dto.response.InstructorClassroomDto;
 import com.app.bdink.instructor.adapter.out.persistence.entity.Instructor;
 import com.app.bdink.instructor.mapper.InstructorMapper;
@@ -254,6 +255,10 @@ public class ClassRoomService implements ClassRoomUseCase {
                 bookmarkCount,
                 classRoomEntity.getInstructor().getMember().getName(),
                 classRoomEntity.getInstructor().getMember().getPictureUrl(),
+                chapterRepository.countByClassRoom(classRoomEntity),
+                lectureRepository.countByClassRoom(classRoomEntity),
+                sugangOpt.get().getExpiredDate(),
+                getTotalTimeFormatted(classRoomEntity.getId()),
                 classRoomEntity.getThumbnail(),
                 payment,
                 classRoomEntity.getPriceDetail(),
@@ -316,5 +321,11 @@ public class ClassRoomService implements ClassRoomUseCase {
     @Transactional(readOnly = true)
     public Boolean isClassRoomBookmarked(Member member, ClassRoomEntity classRoom) {
         return bookmarkRepository.existsByClassRoomAndMember(classRoom, member);
+    }
+
+    public String getTotalTimeFormatted(Long classRoomId) {
+        Long seconds = lectureRepository.getTotalLectureSeconds(classRoomId);
+        if (seconds == null) return "00:00:00";
+        return TotalTimeUtil.formatSecondsToHHMMSS(seconds);
     }
 }

--- a/bdink/src/main/java/com/app/bdink/global/totalTime/TotalTimeUtil.java
+++ b/bdink/src/main/java/com/app/bdink/global/totalTime/TotalTimeUtil.java
@@ -1,0 +1,16 @@
+package com.app.bdink.global.totalTime;
+
+import java.time.Duration;
+
+public class TotalTimeUtil {
+    public static String formatSecondsToHHMMSS(long totalSeconds) {
+        long hours = totalSeconds / 3600;
+        long minutes = (totalSeconds % 3600) / 60;
+        long seconds = totalSeconds % 60;
+        return String.format("%02d:%02d:%02d", hours, minutes, seconds);
+    }
+
+    public static Duration toDuration(long totalSeconds) {
+        return Duration.ofSeconds(totalSeconds);
+    }
+}

--- a/bdink/src/main/java/com/app/bdink/lecture/entity/Lecture.java
+++ b/bdink/src/main/java/com/app/bdink/lecture/entity/Lecture.java
@@ -4,7 +4,6 @@ import com.app.bdink.chapter.entity.Chapter;
 import com.app.bdink.classroom.adapter.out.persistence.entity.ClassRoomEntity;
 import com.app.bdink.common.entity.BaseTimeEntity;
 import com.app.bdink.external.kollus.entity.KollusMedia;
-import com.app.bdink.sugang.entity.Sugang;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -12,7 +11,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalTime;
-import java.util.List;
 
 @Entity
 @Getter

--- a/bdink/src/main/java/com/app/bdink/lecture/entity/Lecture.java
+++ b/bdink/src/main/java/com/app/bdink/lecture/entity/Lecture.java
@@ -40,17 +40,21 @@ public class Lecture extends BaseTimeEntity {
     @Column(name = "media_link")
     private String mediaLink;
 
+    @Column(name = "subtitles")
+    private String subtitles;
+
     // KollusMedia 연관관계 (Lecture 기준 1:1)
     @OneToOne(mappedBy = "lecture")
     private KollusMedia kollusMedia;
 
     @Builder
-    public Lecture(ClassRoomEntity classRoom, Chapter chapter, String title, LocalTime time, String mediaLink) {
+    public Lecture(ClassRoomEntity classRoom, Chapter chapter, String title, LocalTime time, String mediaLink, String subtitles) {
         this.classRoom = classRoom;
         this.chapter = chapter;
         this.title = title;
         this.time = time;
         this.mediaLink = mediaLink;
+        this.subtitles = subtitles;
     }
 
     public void updateKollusMedia(KollusMedia kollusMedia) {

--- a/bdink/src/main/java/com/app/bdink/lecture/repository/LectureRepository.java
+++ b/bdink/src/main/java/com/app/bdink/lecture/repository/LectureRepository.java
@@ -3,6 +3,8 @@ package com.app.bdink.lecture.repository;
 import com.app.bdink.classroom.adapter.out.persistence.entity.ClassRoomEntity;
 import com.app.bdink.lecture.entity.Lecture;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -10,4 +12,12 @@ public interface LectureRepository extends JpaRepository<Lecture, Long> {
     int countByClassRoom(ClassRoomEntity classRoomEntity);
 
     List<Lecture> findAllByClassRoom(ClassRoomEntity classRoomEntity);
+
+    //LocalDate의 합 값을 사용하기 위한 메서드
+    @Query(value = """
+                SELECT SUM(TIME_TO_SEC(time))
+                FROM Lecture
+                WHERE classRoom_id = :classRoomId
+            """, nativeQuery = true)
+    Long getTotalLectureSeconds(@Param("classRoomId") Long classRoomId);
 }

--- a/bdink/src/main/java/com/app/bdink/lecture/service/LectureService.java
+++ b/bdink/src/main/java/com/app/bdink/lecture/service/LectureService.java
@@ -1,7 +1,6 @@
 package com.app.bdink.lecture.service;
 
 import com.app.bdink.chapter.entity.Chapter;
-import com.app.bdink.chapter.repository.ChapterRepository;
 import com.app.bdink.chapter.service.ChapterService;
 import com.app.bdink.classroom.adapter.out.persistence.entity.ClassRoomEntity;
 import com.app.bdink.external.kollus.entity.KollusMedia;

--- a/bdink/src/main/java/com/app/bdink/sugang/controller/dto/response/SugangClassRoomInfo.java
+++ b/bdink/src/main/java/com/app/bdink/sugang/controller/dto/response/SugangClassRoomInfo.java
@@ -8,7 +8,7 @@ public record SugangClassRoomInfo (
         Long lectureId,
         String lectureTitle,
         double lectureProgress,
-        String classRoomThumnail,
+        String classRoomThumbnail,
         String InstructorName
 //        Double progressClassRoom //클래스룸 전체 진행률
 )

--- a/bdink/src/main/java/com/app/bdink/sugang/controller/dto/response/SugangInfoDto.java
+++ b/bdink/src/main/java/com/app/bdink/sugang/controller/dto/response/SugangInfoDto.java
@@ -3,9 +3,12 @@ package com.app.bdink.sugang.controller.dto.response;
 import com.app.bdink.sugang.controller.dto.SugangStatus;
 import com.app.bdink.sugang.entity.Sugang;
 
+import java.time.LocalDate;
+
 public record SugangInfoDto(
         Long sugangId,
         Long memberId,
+        LocalDate expiredDate,
         Long classRoomEntityId,
         SugangStatus sugangStatus
 
@@ -14,6 +17,7 @@ public record SugangInfoDto(
         return new SugangInfoDto(
                 sugang.getId(),
                 sugang.getMember().getId(),
+                sugang.getExpiredDate(),
                 sugang.getClassRoomEntity().getId(),
                 sugang.getSugangStatus()
         );


### PR DESCRIPTION
## 관련이슈
- #279 

## 관련 내용
- classRoom detail 정보 조회 api 200 응답값에 field 추가
- field
   - 챕터 수
   - 클래스룸 총 강의 수
   - 만료일 (수강안했을경우 null값)
   - 자막지원 데이터 (String)