### PR TITLE
[Hotfix] 토큰 재발급 API 500 에러 해결

### DIFF
--- a/bdink/src/main/java/com/app/bdink/global/exception/Error.java
+++ b/bdink/src/main/java/com/app/bdink/global/exception/Error.java
@@ -121,6 +121,7 @@ public enum Error {
     EXPIRED_APPLE_IDENTITY_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 아이덴티티 토큰입니다."),
     UN_AUTHORIZED(HttpStatus.UNAUTHORIZED, "토큰 인증을 안한 유저입니다."),
     UNAUTHORIZED_KEY(HttpStatus.UNAUTHORIZED, "인증되지 않은 시크릿 키 혹은 클라이언트 키 입니다."),
+    INVALID_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
 
     /**
      * 402 PAYMENT REQUIRED

--- a/bdink/src/main/java/com/app/bdink/global/token/TokenProvider.java
+++ b/bdink/src/main/java/com/app/bdink/global/token/TokenProvider.java
@@ -119,6 +119,27 @@ public class TokenProvider {
         }
     }
 
+    /**
+     * 리프레시 토큰에서 memberId 추출
+     * 리프레시 토큰 재발급 시 사용
+     */
+    public Long getMemberIdFromRefreshToken(String refreshToken) {
+        try {
+            Claims claims = parseClaims(refreshToken);
+            String subject = claims.getSubject();
+
+            if (subject == null || subject.isEmpty()) {
+                throw new CustomException(Error.INVALID_TOKEN_EXCEPTION, "토큰에 사용자 정보가 없습니다.");
+            }
+
+            return Long.valueOf(subject);
+        } catch (NumberFormatException e) {
+            throw new CustomException(Error.INVALID_TOKEN_EXCEPTION, "유효하지 않은 사용자 ID 형식입니다.");
+        } catch (Exception e) {
+            throw new CustomException(Error.INVALID_TOKEN_EXCEPTION, "리프레시 토큰에서 사용자 정보를 추출할 수 없습니다.");
+        }
+    }
+
     // 클레임 파싱
     private Claims parseClaims(String accessToken) {
         try {

--- a/bdink/src/main/java/com/app/bdink/oauth2/controller/SocialAuthController.java
+++ b/bdink/src/main/java/com/app/bdink/oauth2/controller/SocialAuthController.java
@@ -111,10 +111,8 @@ public class SocialAuthController {
 
     @PostMapping("/token")
     @Operation(method = "POST", description = "리프레시토큰을 통해 엑세스, 리프레시토큰을 발급받습니다. 이 API에서 에러가 나오는 경우 리프레시도 만료된 케이스 이기 때문에 새로 로그인 하는 방식을 생각하고 있습니다.")
-    public RspTemplate<?> reIssueToken(
-            @RequestBody RefreshToken token,
-            Principal principal) {
-        Long memberId = memberUtilService.getMemberId(principal);
+    public RspTemplate<?> reIssueToken(@RequestBody RefreshToken token) {
+        Long memberId = tokenProvider.getMemberIdFromRefreshToken(token.refreshToken());
         CommonOauthDto commonOauthDto = new CommonOauthDto(authService.reIssueToken(token), memberId);
         return RspTemplate.success(Success.RE_ISSUE_TOKEN_SUCCESS, commonOauthDto);
     }

--- a/bdink/src/main/java/com/app/bdink/oauth2/domain/RefreshToken.java
+++ b/bdink/src/main/java/com/app/bdink/oauth2/domain/RefreshToken.java
@@ -1,9 +1,5 @@
 package com.app.bdink.oauth2.domain;
 
-import lombok.Getter;
-
 public record RefreshToken(
         String refreshToken
-)
-{
-}
+) {}


### PR DESCRIPTION
#287 
만료된 accesstoken이 들어오기 때문에 principle로 memberId를 구할 경우 nullpointexception이 발생할 가능성이 있습니다.
따라서 request body로 들어오는 refreshtoken을 통해 memberId를 구하도록 수정하였습니다.