### PR TITLE
[Modify] Kollus url 발급 API 이전, 다음 강의 정보 추가

### DIFF
--- a/bdink/src/main/java/com/app/bdink/external/kollus/dto/response/KollusApiResponse.java
+++ b/bdink/src/main/java/com/app/bdink/external/kollus/dto/response/KollusApiResponse.java
@@ -13,5 +13,7 @@ public class KollusApiResponse {
         private String url;
         private String lectureTitle;
         private String InstructorName;
+        private Long prevLectureId;
+        private Long nextLectureId;
     }
 }

--- a/bdink/src/main/java/com/app/bdink/lecture/controller/LectureController.java
+++ b/bdink/src/main/java/com/app/bdink/lecture/controller/LectureController.java
@@ -61,7 +61,7 @@ public class LectureController {
 
         //todo:kollus 미디어 링크나 미디어를 연결하는 로직을 생성 기존에 생각했던건 미디어를 강좌와 연결
 
-        return RspTemplate.success(Success.CREATE_LECTURE_SUCCESS, CreateIdDto.from(lectureService.createLecture(chapterId, lectureDto, kollusMedia)));
+        return RspTemplate.success(Success.CREATE_LECTURE_SUCCESS, CreateIdDto.from(lectureService.createLecture(classRoomId ,chapterId, lectureDto, kollusMedia)));
     }
 
     @GetMapping

--- a/bdink/src/main/java/com/app/bdink/lecture/entity/Lecture.java
+++ b/bdink/src/main/java/com/app/bdink/lecture/entity/Lecture.java
@@ -38,21 +38,21 @@ public class Lecture extends BaseTimeEntity {
     @Column(name = "media_link")
     private String mediaLink;
 
-    @Column(name = "subtitles")
-    private String subtitles;
-
     // KollusMedia 연관관계 (Lecture 기준 1:1)
     @OneToOne(mappedBy = "lecture")
     private KollusMedia kollusMedia;
 
+    @Column(name = "sort_order")
+    private Integer sortOrder;
+
     @Builder
-    public Lecture(ClassRoomEntity classRoom, Chapter chapter, String title, LocalTime time, String mediaLink, String subtitles) {
+    public Lecture(ClassRoomEntity classRoom, Chapter chapter, String title, LocalTime time, String mediaLink, Integer sortOrder) {
         this.classRoom = classRoom;
         this.chapter = chapter;
         this.title = title;
         this.time = time;
         this.mediaLink = mediaLink;
-        this.subtitles = subtitles;
+        this.sortOrder = sortOrder;
     }
 
     public void updateKollusMedia(KollusMedia kollusMedia) {

--- a/bdink/src/main/java/com/app/bdink/lecture/repository/LectureRepository.java
+++ b/bdink/src/main/java/com/app/bdink/lecture/repository/LectureRepository.java
@@ -13,6 +13,12 @@ public interface LectureRepository extends JpaRepository<Lecture, Long> {
 
     List<Lecture> findAllByClassRoom(ClassRoomEntity classRoomEntity);
 
+    List<Lecture> findByClassRoomIdOrderBySortOrderAsc(Long classRoomId);
+
+
+    @Query("SELECT MAX(l.sortOrder) FROM Lecture l WHERE l.classRoom.id = :classRoomId")
+    Integer findMaxSortOrderByClassRoom(@Param("classRoomId") Long classRoomId);
+
     //LocalDate의 합 값을 사용하기 위한 메서드
     @Query(value = """
                 SELECT SUM(TIME_TO_SEC(time))

--- a/bdink/src/main/java/com/app/bdink/lecture/service/LectureService.java
+++ b/bdink/src/main/java/com/app/bdink/lecture/service/LectureService.java
@@ -31,13 +31,17 @@ public class LectureService {
 
     //chapter에 강좌 추가
     @Transactional
-    public String createLecture(final Long chapterId,
+    public String createLecture(final Long classRoomId, final Long chapterId,
                                 final LectureDto lectureDto, final KollusMedia kollusMedia){
         String mediaContentKey = kollusMedia.getMediaContentKey(); //todo:kollus id를 가져올 필요가 없을것 같음.
 
         Chapter chapter = chapterService.findWithClassRoomById(chapterId);
 
         ClassRoomEntity classRoom = chapter.getClassRoom();
+
+        Integer maxSortOrder = lectureRepository.findMaxSortOrderByClassRoom(classRoomId);
+
+        int nextSortOrder = (maxSortOrder != null ? maxSortOrder : 0) + 1;
 
         log.info("클래스룸 id는 값 : {}", classRoom.getId());
 
@@ -48,6 +52,7 @@ public class LectureService {
                         .title(lectureDto.title())
                         .time(lectureDto.convertToLocalTime())
                         .mediaLink(mediaContentKey)
+                        .sortOrder(nextSortOrder)
                         .build());
 
         chapter.addLectures(lecture);


### PR DESCRIPTION
## 관련 이슈
- #286 

## 관련 내용
- Kollus url 발급 api 200 응답에 "prevLectureId", "nextLectureId" 정보 저장, 각각 이전 다음 강의 id를 반환