### PR TITLE
[Fix] 애플 인앱 결제 복원을 대비한 구현부 수정

### DIFF
--- a/bdink/src/main/java/com/app/bdink/payment/apple/entity/ApplePurchaseHistory.java
+++ b/bdink/src/main/java/com/app/bdink/payment/apple/entity/ApplePurchaseHistory.java
@@ -12,6 +12,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Table(uniqueConstraints = {
+        @UniqueConstraint(
+                name = "uk_user_original_transaction_product",
+                columnNames = {"user_id", "original_transaction_id", "product_id"}
+        )
+})
 public class ApplePurchaseHistory extends BaseTimeEntity {
 
     @Id
@@ -25,15 +31,19 @@ public class ApplePurchaseHistory extends BaseTimeEntity {
     @Column(name = "product_id", nullable = false)
     private String productId;
 
-    @Column(name = "transaction_id", unique = true, nullable = false)
+    @Column(name = "transaction_id", nullable = false)
     private String transactionId;
 
+    @Column(name = "original_transaction_id", nullable = false)
+    private String originalTransactionId;
+
     public static ApplePurchaseHistory createPurchase(
-            Long userId, String productId, String transactionId) {
+            Long userId, String productId, String transactionId, String originalTransactionId) {
         return ApplePurchaseHistory.builder()
                 .userId(userId)
                 .productId(productId)
                 .transactionId(transactionId)
+                .originalTransactionId(originalTransactionId)
                 .build();
     }
 }

--- a/bdink/src/main/java/com/app/bdink/payment/apple/repository/ApplePurchaseHistoryRepository.java
+++ b/bdink/src/main/java/com/app/bdink/payment/apple/repository/ApplePurchaseHistoryRepository.java
@@ -4,9 +4,11 @@ import com.app.bdink.payment.apple.entity.ApplePurchaseHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ApplePurchaseHistoryRepository extends JpaRepository<ApplePurchaseHistory, Long> {
 
-    Boolean existsByTransactionId(String transactionId);
     List<ApplePurchaseHistory> findAllByUserId(Long memberId);
+    boolean existsByUserIdAndOriginalTransactionIdAndProductId(Long memberId, String originalTransactionId, String productId);
+    Optional<ApplePurchaseHistory> findByUserIdAndOriginalTransactionIdAndProductId(Long memberId, String originalTransactionId, String productId);
 }


### PR DESCRIPTION
## #303 애플 인앱 결제 복원을 대비한 구현부 수정
애플 결제에서 해당 결제의 transaction_id는 유일하지만, iOS 사용자가 결제를 복원할 경우 새로운 transaction_id가 발급되기 때문에 기존에 transaction_id를 unique로 두었던 부분을 아래와 같이 수정했습니다. 
```
@Table(uniqueConstraints = {
        @UniqueConstraint(
                name = "uk_user_original_transaction_product",
                columnNames = {"user_id", "original_transaction_id", "product_id"}
        )
})
public class ApplePurchaseHistory extends BaseTimeEntity {
```
또한 ApplePaymentServiceImpl에서 결제가 중복인지 여부를 판단할 때도 위의 uniqueConstraint를 따르도록 수정하였습니다.
