### PR TITLE
[Fix] 결제 취소 후 수강 상태가 변경되지 않는 버그 해결

### DIFF
--- a/bdink/src/main/java/com/app/bdink/global/exception/Error.java
+++ b/bdink/src/main/java/com/app/bdink/global/exception/Error.java
@@ -194,7 +194,9 @@ public enum Error {
     COMMON_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요."),
     PAYMENT_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "결제는 성공적으로 처리되었으나, 시스템에 주문 정보를 저장하는 과정에서 오류가 발생했습니다."),
 
-    PAYMENT_PROCESSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "결제 처리 중 오류가 발생했습니다");
+    PAYMENT_PROCESSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "결제 처리 중 오류가 발생했습니다"),
+
+    SUGANG_STATUS_UPDATE(HttpStatus.INTERNAL_SERVER_ERROR, "수강 결제 상태를 변경하지 못했습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/bdink/src/main/java/com/app/bdink/payment/apple/service/ApplePaymentServiceImpl.java
+++ b/bdink/src/main/java/com/app/bdink/payment/apple/service/ApplePaymentServiceImpl.java
@@ -6,6 +6,7 @@ import com.app.bdink.payment.apple.repository.AppleProductRepository;
 import com.app.bdink.payment.apple.dto.*;
 import com.app.bdink.payment.apple.entity.AppleProduct;
 import com.app.bdink.payment.apple.repository.ApplePurchaseHistoryRepository;
+import com.app.bdink.payment.transactional.PaymentTransactionalService;
 import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.http.*;
@@ -31,6 +32,9 @@ public class ApplePaymentServiceImpl implements ApplePaymentService {
     private final AppleProductRepository appleProductRepository;
     private final ApplePurchaseHistoryRepository applePurchaseHistoryRepository;
     private final RestTemplate restTemplate;
+
+    // 결제 취소에 대한 처리 필요
+    private final PaymentTransactionalService paymentTransactionalService;
 
     @Override
     public List<AppleProductResponse> getAllProducts() {

--- a/bdink/src/main/java/com/app/bdink/payment/toss/controller/PaymentController.java
+++ b/bdink/src/main/java/com/app/bdink/payment/toss/controller/PaymentController.java
@@ -54,7 +54,9 @@ public class PaymentController {
                     "결제 금액의 일부만 부분 취소하려면 cancelAmount에 취소할 금액을 추가해서 API를 요청합니다. " +
                     "cancelAmount에 값을 넣지 않으면 전액 취소됩니다. cancelAmout에 빈문자열을 넣으면 전액 취소됩니다.")
     public Mono<RspTemplate<PaymentResponse>> cancelPayment(
+            Principal principal,
             @PathVariable String paymentKey, @RequestBody CancelRequest cancelRequest) {
-        return paymentService.cancelPayment(paymentKey, cancelRequest);
+        Long memberId = memberUtilService.getMemberId(principal);
+        return paymentService.cancelPayment(paymentKey, cancelRequest, memberId);
     }
 }

--- a/bdink/src/main/java/com/app/bdink/payment/toss/controller/dto/CancelRequest.java
+++ b/bdink/src/main/java/com/app/bdink/payment/toss/controller/dto/CancelRequest.java
@@ -2,5 +2,6 @@ package com.app.bdink.payment.toss.controller.dto;
 
 public record CancelRequest(
         String cancelReason,
-        Integer cancelAmount
+        Integer cancelAmount,
+        Long cancelClassRoomId
 ) {}

--- a/bdink/src/main/java/com/app/bdink/payment/toss/service/PaymentService.java
+++ b/bdink/src/main/java/com/app/bdink/payment/toss/service/PaymentService.java
@@ -8,6 +8,7 @@ import com.app.bdink.member.exception.NotFoundMemberException;
 import com.app.bdink.payment.toss.controller.dto.CancelRequest;
 import com.app.bdink.payment.toss.controller.dto.ConfirmRequest;
 import com.app.bdink.payment.toss.controller.dto.PaymentResponse;
+import com.app.bdink.payment.transactional.PaymentTransactionalService;
 import com.app.bdink.sugang.controller.dto.SugangStatus;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -36,7 +37,7 @@ public class PaymentService {
 
     private final String tossUrl = "https://api.tosspayments.com/v1/payments";
 
-    private final TransactionalPaymentService transactionalPaymentService;
+    private final PaymentTransactionalService paymentTransactionalService;
 
     public Mono<RspTemplate<PaymentResponse>> confirm(Long memberId, ConfirmRequest confirmRequest) throws CustomException {
         log.info(">>> ConfirmRequest: {}", confirmRequest);
@@ -60,7 +61,7 @@ public class PaymentService {
                 .bodyToMono(PaymentResponse.class)
                 .flatMap(response ->
                         Mono.fromCallable(() ->
-                                        transactionalPaymentService.savePaymentTransactional(memberId, response)
+                                        paymentTransactionalService.savePaymentTransactional(memberId, response)
                                 )
                                 .subscribeOn(Schedulers.boundedElastic())
                                 .thenReturn(response)
@@ -116,7 +117,7 @@ public class PaymentService {
                 ).bodyToMono(PaymentResponse.class)
                 .flatMap(response ->
                         Mono.fromRunnable(() ->
-                                        transactionalPaymentService.updateSugangStatus(
+                                        paymentTransactionalService.updateSugangStatus(
                                                 memberId, cancelRequest.cancelClassRoomId(), SugangStatus.PAYMENT_REFUNDED)
                                 )
                                 .subscribeOn(Schedulers.boundedElastic())

--- a/bdink/src/main/java/com/app/bdink/payment/toss/service/PaymentService.java
+++ b/bdink/src/main/java/com/app/bdink/payment/toss/service/PaymentService.java
@@ -8,6 +8,7 @@ import com.app.bdink.member.exception.NotFoundMemberException;
 import com.app.bdink.payment.toss.controller.dto.CancelRequest;
 import com.app.bdink.payment.toss.controller.dto.ConfirmRequest;
 import com.app.bdink.payment.toss.controller.dto.PaymentResponse;
+import com.app.bdink.sugang.controller.dto.SugangStatus;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -101,7 +102,7 @@ public class PaymentService {
     }
 
     public Mono<RspTemplate<PaymentResponse>> cancelPayment(
-            String paymentKey, CancelRequest cancelRequest, Long memberId, Long classRoomId) {
+            String paymentKey, CancelRequest cancelRequest, Long memberId) {
         String authorization = getBasicAuthHeader();
         WebClient webClient = WebClient.create(tossUrl);
         Mono<PaymentResponse> responseMono = webClient.post()
@@ -115,7 +116,8 @@ public class PaymentService {
                 ).bodyToMono(PaymentResponse.class)
                 .flatMap(response ->
                         Mono.fromRunnable(() ->
-                                        transactionalPaymentService.updateSugangStatusToPaymentRefunded(memberId, classRoomId)
+                                        transactionalPaymentService.updateSugangStatus(
+                                                memberId, cancelRequest.cancelClassRoomId(), SugangStatus.PAYMENT_REFUNDED)
                                 )
                                 .subscribeOn(Schedulers.boundedElastic())
                                 .thenReturn(response)

--- a/bdink/src/main/java/com/app/bdink/payment/toss/service/PaymentService.java
+++ b/bdink/src/main/java/com/app/bdink/payment/toss/service/PaymentService.java
@@ -113,6 +113,8 @@ public class PaymentService {
                         this::handleErrorResponse
                 ).bodyToMono(PaymentResponse.class);
 
+
+
         return toRspTemplate(responseMono, Success.CANCEL_TOSS_PAYMENT_SUCCESS);
     }
 

--- a/bdink/src/main/java/com/app/bdink/payment/toss/service/TransactionalPaymentService.java
+++ b/bdink/src/main/java/com/app/bdink/payment/toss/service/TransactionalPaymentService.java
@@ -22,8 +22,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class TransactionalPaymentService {
 
-    private final SugangService sugangService;
-
     private final EssentialPaymentRepository essentialPaymentRepository;
     private final MemberRepository memberRepository;
     private final SugangRepository sugangRepository;
@@ -39,7 +37,7 @@ public class TransactionalPaymentService {
     }
 
     @Transactional
-    public void updateSugangStatusToPaymentRefunded(Long memberId, Long classRoomId) {
+    public void updateSugangStatus(Long memberId, Long classRoomId, SugangStatus sugangStatus) {
         Member member = memberRepository.findById(memberId).orElseThrow(
                 () -> new NotFoundMemberException(Error.NOT_FOUND_USER_EXCEPTION, Error.NOT_FOUND_USER_EXCEPTION.getMessage())
         );
@@ -49,6 +47,6 @@ public class TransactionalPaymentService {
         Sugang sugang = sugangRepository.findByMemberAndClassRoomEntity(member, classRoomEntity).orElseThrow(
                 () -> new NotFoundException(Error.NOT_FOUND_SUGANG, Error.NOT_FOUND_SUGANG.getMessage())
         );
-        sugang.updateSugangStatus(SugangStatus.PAYMENT_REFUNDED);
+        sugang.updateSugangStatus(sugangStatus);
     }
 }

--- a/bdink/src/main/java/com/app/bdink/payment/toss/service/TransactionalPaymentService.java
+++ b/bdink/src/main/java/com/app/bdink/payment/toss/service/TransactionalPaymentService.java
@@ -1,12 +1,19 @@
 package com.app.bdink.payment.toss.service;
 
+import com.app.bdink.classroom.adapter.out.persistence.entity.ClassRoomEntity;
+import com.app.bdink.classroom.repository.ClassRoomRepository;
 import com.app.bdink.global.exception.Error;
+import com.app.bdink.global.exception.model.NotFoundException;
 import com.app.bdink.member.entity.Member;
 import com.app.bdink.member.exception.NotFoundMemberException;
 import com.app.bdink.member.repository.MemberRepository;
 import com.app.bdink.payment.toss.controller.dto.PaymentResponse;
 import com.app.bdink.payment.toss.entity.EssentialPayment;
 import com.app.bdink.payment.toss.repository.EssentialPaymentRepository;
+import com.app.bdink.sugang.controller.dto.SugangStatus;
+import com.app.bdink.sugang.entity.Sugang;
+import com.app.bdink.sugang.repository.SugangRepository;
+import com.app.bdink.sugang.service.SugangService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,15 +22,33 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class TransactionalPaymentService {
 
+    private final SugangService sugangService;
+
     private final EssentialPaymentRepository essentialPaymentRepository;
     private final MemberRepository memberRepository;
+    private final SugangRepository sugangRepository;
+    private final ClassRoomRepository classRoomRepository;
 
     @Transactional
     public EssentialPayment savePaymentTransactional(Long memberId, PaymentResponse response) {
         Member member = memberRepository.findById(memberId).orElseThrow(
-                () -> new NotFoundMemberException(Error.NOT_FOUND_USER_EXCEPTION, "해당 멤버를 찾지 못했습니다.")
+                () -> new NotFoundMemberException(Error.NOT_FOUND_USER_EXCEPTION, Error.NOT_FOUND_USER_EXCEPTION.getMessage())
         );
         EssentialPayment payment = EssentialPayment.from(member, response);
         return essentialPaymentRepository.save(payment);
+    }
+
+    @Transactional
+    public void updateSugangStatusToPaymentRefunded(Long memberId, Long classRoomId) {
+        Member member = memberRepository.findById(memberId).orElseThrow(
+                () -> new NotFoundMemberException(Error.NOT_FOUND_USER_EXCEPTION, Error.NOT_FOUND_USER_EXCEPTION.getMessage())
+        );
+        ClassRoomEntity classRoomEntity = classRoomRepository.findById(classRoomId).orElseThrow(
+                () -> new NotFoundException(Error.NOT_FOUND_CLASSROOM, Error.NOT_FOUND_CLASSROOM.getMessage())
+        );
+        Sugang sugang = sugangRepository.findByMemberAndClassRoomEntity(member, classRoomEntity).orElseThrow(
+                () -> new NotFoundException(Error.NOT_FOUND_SUGANG, Error.NOT_FOUND_SUGANG.getMessage())
+        );
+        sugang.updateSugangStatus(SugangStatus.PAYMENT_REFUNDED);
     }
 }

--- a/bdink/src/main/java/com/app/bdink/payment/transactional/PaymentTransactionalService.java
+++ b/bdink/src/main/java/com/app/bdink/payment/transactional/PaymentTransactionalService.java
@@ -1,0 +1,26 @@
+package com.app.bdink.payment.transactional;
+
+import com.app.bdink.payment.toss.controller.dto.PaymentResponse;
+import com.app.bdink.payment.toss.entity.EssentialPayment;
+import com.app.bdink.sugang.controller.dto.SugangStatus;
+
+public interface PaymentTransactionalService {
+
+    /**
+     * 결제 정보를 트랜잭션 내에서 저장합니다.
+     *
+     * @param memberId 회원 ID
+     * @param response 결제 응답 정보
+     * @return 저장된 EssentialPayment 엔티티
+     */
+    EssentialPayment savePaymentTransactional(Long memberId, PaymentResponse response);
+
+    /**
+     * 수강 상태를 업데이트합니다.
+     *
+     * @param memberId 회원 ID
+     * @param classRoomId 강의실 ID
+     * @param sugangStatus 변경할 수강 상태
+     */
+    void updateSugangStatus(Long memberId, Long classRoomId, SugangStatus sugangStatus);
+}

--- a/bdink/src/main/java/com/app/bdink/payment/transactional/PaymentTransactionalServiceImpl.java
+++ b/bdink/src/main/java/com/app/bdink/payment/transactional/PaymentTransactionalServiceImpl.java
@@ -1,4 +1,4 @@
-package com.app.bdink.payment.toss.service;
+package com.app.bdink.payment.transactional;
 
 import com.app.bdink.classroom.adapter.out.persistence.entity.ClassRoomEntity;
 import com.app.bdink.classroom.repository.ClassRoomRepository;
@@ -13,14 +13,13 @@ import com.app.bdink.payment.toss.repository.EssentialPaymentRepository;
 import com.app.bdink.sugang.controller.dto.SugangStatus;
 import com.app.bdink.sugang.entity.Sugang;
 import com.app.bdink.sugang.repository.SugangRepository;
-import com.app.bdink.sugang.service.SugangService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class TransactionalPaymentService {
+public class PaymentTransactionalServiceImpl implements PaymentTransactionalService {
 
     private final EssentialPaymentRepository essentialPaymentRepository;
     private final MemberRepository memberRepository;

--- a/bdink/src/main/java/com/app/bdink/sugang/service/SugangService.java
+++ b/bdink/src/main/java/com/app/bdink/sugang/service/SugangService.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 
 @Service
 @Slf4j
@@ -119,4 +120,10 @@ public class SugangService {
         log.info("progress3 : {}", sugang.getProgressPercent());
     }
 
+    @Transactional
+    public void updateSugangStatus(Long sugangId, SugangStatus sugangStatus) {
+        Sugang sugang = sugangRepository.findById(sugangId).orElseThrow(
+                () -> new CustomException(Error.NOT_FOUND_SUGANG, Error.NOT_FOUND_SUGANG.getMessage()));
+        sugang.updateSugangStatus(sugangStatus);
+    }
 }

--- a/bdink/src/main/java/com/app/bdink/sugang/service/SugangService.java
+++ b/bdink/src/main/java/com/app/bdink/sugang/service/SugangService.java
@@ -119,11 +119,4 @@ public class SugangService {
         sugangRepository.save(sugang);
         log.info("progress3 : {}", sugang.getProgressPercent());
     }
-
-    @Transactional
-    public void updateSugangStatus(Long sugangId, SugangStatus sugangStatus) {
-        Sugang sugang = sugangRepository.findById(sugangId).orElseThrow(
-                () -> new CustomException(Error.NOT_FOUND_SUGANG, Error.NOT_FOUND_SUGANG.getMessage()));
-        sugang.updateSugangStatus(sugangStatus);
-    }
 }


### PR DESCRIPTION
## #313 결제 취소 후 수강 상태가 변경되지 않는 버그 해결

토스 결제 승인 -> 수강 POST API 호출 -> 토스 결제 취소 -> 내부적으로 수강 status PAYMENT_REFUNDED로 수정합니다.
애플 인앱 결제에는 아직 결제 취소 기능이 구현되지 않았지만, 애플 인앱 결제에서도 동일하게 적용될 예정입니다.