### PR TITLE
[Fix] appleProduct canParchase 수정

### DIFF
--- a/bdink/src/main/java/com/app/bdink/global/exception/Error.java
+++ b/bdink/src/main/java/com/app/bdink/global/exception/Error.java
@@ -196,7 +196,8 @@ public enum Error {
 
     PAYMENT_PROCESSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "결제 처리 중 오류가 발생했습니다"),
 
-    SUGANG_STATUS_UPDATE(HttpStatus.INTERNAL_SERVER_ERROR, "수강 결제 상태를 변경하지 못했습니다.")
+    SUGANG_STATUS_UPDATE(HttpStatus.INTERNAL_SERVER_ERROR, "수강 결제 상태를 변경하지 못했습니다."),
+    CONCURRENT_PURCHASE_ATTEMPT(HttpStatus.INTERNAL_SERVER_ERROR, "Product is currently being processed by another user")
     ;
 
     private final HttpStatus httpStatus;

--- a/bdink/src/main/java/com/app/bdink/payment/apple/entity/AppleProduct.java
+++ b/bdink/src/main/java/com/app/bdink/payment/apple/entity/AppleProduct.java
@@ -21,6 +21,6 @@ public class AppleProduct extends BaseTimeEntity {
 
     private String productId;
 
-    @Setter
+    // 시스템 차원의 구매 가능 여부
     private Boolean canPurchase;
 }

--- a/bdink/src/main/java/com/app/bdink/payment/apple/entity/AppleProduct.java
+++ b/bdink/src/main/java/com/app/bdink/payment/apple/entity/AppleProduct.java
@@ -4,6 +4,7 @@ import com.app.bdink.classroom.adapter.out.persistence.entity.ClassRoomEntity;
 import com.app.bdink.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.Setter;
 
 @Entity
 @Getter
@@ -20,5 +21,6 @@ public class AppleProduct extends BaseTimeEntity {
 
     private String productId;
 
+    @Setter
     private Boolean canPurchase;
 }

--- a/bdink/src/main/java/com/app/bdink/payment/apple/repository/AppleProductRepository.java
+++ b/bdink/src/main/java/com/app/bdink/payment/apple/repository/AppleProductRepository.java
@@ -1,8 +1,11 @@
 package com.app.bdink.payment.apple.repository;
 
-import com.app.bdink.payment.apple.dto.AppleProductResponse;
 import com.app.bdink.payment.apple.entity.AppleProduct;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -10,4 +13,8 @@ public interface AppleProductRepository extends JpaRepository<AppleProduct, Long
     Optional<AppleProduct> findByProductId(String productId);
 
     Optional<AppleProduct> findByClassRoomId(Long classRoomId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM AppleProduct p WHERE p.productId = :productId")
+    Optional<AppleProduct> findByProductIdWithLock(@Param("productId") String productId);
 }

--- a/bdink/src/main/java/com/app/bdink/payment/apple/repository/AppleProductRepository.java
+++ b/bdink/src/main/java/com/app/bdink/payment/apple/repository/AppleProductRepository.java
@@ -10,11 +10,10 @@ import org.springframework.data.repository.query.Param;
 import java.util.Optional;
 
 public interface AppleProductRepository extends JpaRepository<AppleProduct, Long> {
-    Optional<AppleProduct> findByProductId(String productId);
 
     Optional<AppleProduct> findByClassRoomId(Long classRoomId);
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Lock(LockModeType.PESSIMISTIC_READ)
     @Query("SELECT p FROM AppleProduct p WHERE p.productId = :productId")
     Optional<AppleProduct> findByProductIdWithLock(@Param("productId") String productId);
 }

--- a/bdink/src/main/java/com/app/bdink/payment/apple/repository/ApplePurchaseHistoryRepository.java
+++ b/bdink/src/main/java/com/app/bdink/payment/apple/repository/ApplePurchaseHistoryRepository.java
@@ -1,7 +1,11 @@
 package com.app.bdink.payment.apple.repository;
 
 import com.app.bdink.payment.apple.entity.ApplePurchaseHistory;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -9,6 +13,10 @@ import java.util.Optional;
 public interface ApplePurchaseHistoryRepository extends JpaRepository<ApplePurchaseHistory, Long> {
 
     List<ApplePurchaseHistory> findAllByUserId(Long memberId);
-    boolean existsByUserIdAndOriginalTransactionIdAndProductId(Long memberId, String originalTransactionId, String productId);
+
+    @Lock(LockModeType.PESSIMISTIC_READ)
+    @Query("SELECT ph FROM ApplePurchaseHistory ph WHERE ph.productId = :productId AND ph.userId = :userId")
+    boolean findByUserIdAndProductIdWithLock(@Param("userId") Long userId, @Param("productId") String productId);
+
     Optional<ApplePurchaseHistory> findByUserIdAndOriginalTransactionIdAndProductId(Long memberId, String originalTransactionId, String productId);
 }

--- a/bdink/src/main/java/com/app/bdink/payment/apple/service/ApplePaymentServiceImpl.java
+++ b/bdink/src/main/java/com/app/bdink/payment/apple/service/ApplePaymentServiceImpl.java
@@ -8,7 +8,9 @@ import com.app.bdink.payment.apple.entity.AppleProduct;
 import com.app.bdink.payment.apple.repository.ApplePurchaseHistoryRepository;
 import com.app.bdink.payment.transactional.PaymentTransactionalService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
+import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +24,7 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -62,19 +65,44 @@ public class ApplePaymentServiceImpl implements ApplePaymentService {
 
     @Override
     public PurchaseResponse purchase(Long memberId, PurchaseRequest request) {
-        validateProduct(request.productId());
-        InAppPurchase inAppPurchase = verifyAppleReceipt(request);
-        savePurchaseHistoryWithDuplicateCheck(memberId, inAppPurchase);
-        return createSuccessResponse(inAppPurchase.getTransactionId());
+        return executeSecurePurchase(memberId, request);
     }
 
-    private void validateProduct(String productId) {
-        AppleProduct product = appleProductRepository.findByProductId(productId)
-                .orElseThrow(() -> new PaymentFailedException(Error.PRODUCT_NOT_FOUND, "Product not found: " + productId));
+    private PurchaseResponse executeSecurePurchase(Long memberId, PurchaseRequest request) {
+        // 1. 락을 걸고 상품 조회 및 검증
+        AppleProduct product = acquireProductLock(request.productId());
 
-        if (!product.getCanPurchase()) {
-            throw new PaymentFailedException(Error.PRODUCT_NOT_AVAILABLE,
-                    "Product not available for purchase: " + productId);
+        try {
+            // 2. Apple 영수증 검증
+            InAppPurchase inAppPurchase = verifyAppleReceipt(request);
+            // 3. 구매 이력 저장
+            savePurchaseHistoryWithDuplicateCheck(memberId, inAppPurchase);
+            // 4. 상품 상태 변경
+            product.setCanPurchase(false);
+
+            return createSuccessResponse(inAppPurchase.getTransactionId());
+        } catch (Exception e) {
+            log.error("Purchase failed for member: {}, product: {}, error: {}",
+                    memberId, request.productId(), e.getMessage());
+            throw e;
+        }
+    }
+
+    private AppleProduct acquireProductLock(String productId) {
+        try {
+            AppleProduct product = appleProductRepository.findByProductIdWithLock(productId)
+                    .orElseThrow(() -> new PaymentFailedException(Error.PRODUCT_NOT_FOUND,
+                            "Product not found: " + productId));
+
+            if (!product.getCanPurchase()) {
+                throw new PaymentFailedException(Error.PRODUCT_NOT_AVAILABLE,
+                        "Product not available for purchase: " + productId);
+            }
+
+            return product;
+        } catch (PessimisticLockingFailureException e) {
+            throw new PaymentFailedException(Error.CONCURRENT_PURCHASE_ATTEMPT,
+                    Error.CONCURRENT_PURCHASE_ATTEMPT.getMessage());
         }
     }
 


### PR DESCRIPTION
[Feature] Apple 결제 시스템 동시성 제어 개선 및 canPurchase 인스턴스 수정

중복 결제 방지 로직 추가
AppleProduct의 canPurchase는 시스템 차원에서 해당 강의가 구매 가능한지를 나타냅니다.