### PR TITLE
[Fix] existingPurchases boolean 값 구하는 쿼리문 수정

### DIFF
--- a/bdink/src/main/java/com/app/bdink/payment/apple/repository/ApplePurchaseHistoryRepository.java
+++ b/bdink/src/main/java/com/app/bdink/payment/apple/repository/ApplePurchaseHistoryRepository.java
@@ -15,7 +15,10 @@ public interface ApplePurchaseHistoryRepository extends JpaRepository<ApplePurch
     List<ApplePurchaseHistory> findAllByUserId(Long memberId);
 
     @Lock(LockModeType.PESSIMISTIC_READ)
-    @Query("SELECT ph FROM ApplePurchaseHistory ph WHERE ph.productId = :productId AND ph.userId = :userId")
+//    @Query("SELECT ph FROM ApplePurchaseHistory ph WHERE ph.productId = :productId AND ph.userId = :userId")
+    @Query("SELECT CASE WHEN COUNT(p) > 0 THEN true ELSE false END " +
+            "FROM ApplePurchaseHistory p " +
+            "WHERE p.userId = :userId AND p.productId = :productId")
     boolean findByUserIdAndProductIdWithLock(@Param("userId") Long userId, @Param("productId") String productId);
 
     Optional<ApplePurchaseHistory> findByUserIdAndOriginalTransactionIdAndProductId(Long memberId, String originalTransactionId, String productId);


### PR DESCRIPTION
## #340 existingPurchases boolean 값 구하는 쿼리문 수정

acquireProductLock 메소드에서 구매 이력 여부를 판별하는 existingPurchases 변수에서 null이 들어오는 SQL 쿼리문 때문에 발생했던 500 에러를 해결했습니다.