### PR TITLE
[Modify] 기존 강사만 분기처리 구조에서 강사, 센터장, 일반유저로 분기처리

### DIFF
--- a/bdink/src/main/java/com/app/bdink/centerowner/repository/CenterOwnerRepository.java
+++ b/bdink/src/main/java/com/app/bdink/centerowner/repository/CenterOwnerRepository.java
@@ -16,6 +16,8 @@ public interface CenterOwnerRepository extends JpaRepository<CenterOwner, Long> 
 
     Optional<CenterOwner> findByCenterIdAndMemberId(Long centerId, Long memberId);
 
+    Optional<CenterOwner> findByMemberId(Long memberId);
+
     boolean existsByCenterIdAndMemberIdAndStatus(Long centerId, Long memberId, CenterOwnerStatus status);
 
     List<CenterOwner> findAllByCenterIdAndStatus(Long centerId, CenterOwnerStatus status);

--- a/bdink/src/main/java/com/app/bdink/mypage/dto/response/MyPageResponse.java
+++ b/bdink/src/main/java/com/app/bdink/mypage/dto/response/MyPageResponse.java
@@ -6,13 +6,18 @@ import lombok.Builder;
 @Builder
 public record MyPageResponse (
         Boolean isInstructor,
+        // Trainer or CenterOwner
+        Boolean isTrainer,
+        Boolean isUser,
         String memberProfile,
         String memberEmail,
         String memberName
 ) {
-    public static MyPageResponse of(Member member, Boolean isInstructor) {
+    public static MyPageResponse of(Member member, Boolean isInstructor, Boolean isTrainer, Boolean isUser) {
         return MyPageResponse.builder()
                 .isInstructor(isInstructor)
+                .isTrainer(isTrainer)
+                .isUser(isUser)
                 .memberEmail(member.getEmail())
                 .memberProfile(member.getPictureUrl())
                 .memberName(member.getName())

--- a/bdink/src/main/java/com/app/bdink/mypage/service/MyPageService.java
+++ b/bdink/src/main/java/com/app/bdink/mypage/service/MyPageService.java
@@ -1,9 +1,13 @@
 package com.app.bdink.mypage.service;
 
+import com.app.bdink.centerowner.entity.CenterOwner;
+import com.app.bdink.centerowner.repository.CenterOwnerRepository;
 import com.app.bdink.instructor.adapter.out.persistence.entity.Instructor;
 import com.app.bdink.instructor.repository.InstructorRepository;
 import com.app.bdink.member.entity.Member;
 import com.app.bdink.mypage.dto.response.MyPageResponse;
+import com.app.bdink.trainer.entity.Trainer;
+import com.app.bdink.trainer.repository.TrainerRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -16,14 +20,30 @@ import java.util.Optional;
 public class MyPageService {
 
     private final InstructorRepository instructorRepository;
+    private final TrainerRepository trainerRepository;
+    private final CenterOwnerRepository centerOwnerRepository;
 
     public MyPageResponse getMemberInfo(Member member) {
-        Boolean isInstructor = false;
+        boolean isInstructor = false;
+        boolean isTrainer = false;
+        boolean isUser = false;
         Optional<Instructor> instructor = instructorRepository.findByMemberId(member.getId());
+        Optional<Trainer> trainer =  trainerRepository.findByMemberId(member.getId());
+        Optional<CenterOwner> centerOwner = centerOwnerRepository.findByMemberId(member.getId());
+
+
+        /***
+         * 현재 강사와 트레이너가 분리되어있다고 가정 후 진행
+         */
         if (instructor.isPresent()) {
             isInstructor = true;
         }
+        //trainer와 centerOwner는 같은 역할로 취급
+        else if (trainer.isPresent() || centerOwner.isPresent()) {
+            isTrainer = true;
+        }else
+            isUser = true;
 
-        return MyPageResponse.of(member, isInstructor);
+        return MyPageResponse.of(member, isInstructor, isTrainer, isUser);
     }
 }


### PR DESCRIPTION
## 이슈번호
- #432 
## 작업내용
- Mypage api에서 새로운 직함이 추가됨에 따라 기존 강사만 확인했던 응답 dto에서 유저, 강사, 트레이너로 분기처리