### PR TITLE
[Feat] 회원 피드백에 사진 및 동영상 첨부 기능 추가

### DIFF
--- a/bdink/src/main/java/com/app/bdink/external/aws/s3/controller/S3MultipartController.java
+++ b/bdink/src/main/java/com/app/bdink/external/aws/s3/controller/S3MultipartController.java
@@ -36,7 +36,7 @@ public class S3MultipartController {
     }
 
     @PostMapping("/complete-upload")
-    @Operation(method = "POST", description = "다 presignUrl에 넣으셨다면 이 API를 호출해서 완료시켜주면 서버에서 영상을 합치겠습니다.")
+    @Operation(method = "POST", description = "다 presignUrl에 넣으셨다면 이 API를 호출해서 완료시켜주면 서버에서 영상을 합치겠습니다.(강의 등록)")
     public RspTemplate<S3UploadResultDto> completeUpload(@RequestBody S3UploadCompleteDto s3UploadCompleteDto, @RequestParam Long lectureId){
         S3UploadResultDto result = s3MultipartService.completeUpload(s3UploadCompleteDto);
         Media media = mediaService.createLecture(lectureId, result.url(), s3UploadCompleteDto.uploadId(), null);

--- a/bdink/src/main/java/com/app/bdink/external/aws/service/S3MultipartService.java
+++ b/bdink/src/main/java/com/app/bdink/external/aws/service/S3MultipartService.java
@@ -103,6 +103,4 @@ public class S3MultipartService {
                 .url(url)
                 .build();
     }
-
-
 }

--- a/bdink/src/main/java/com/app/bdink/workout/controller/WorkoutController.java
+++ b/bdink/src/main/java/com/app/bdink/workout/controller/WorkoutController.java
@@ -6,6 +6,8 @@ import com.app.bdink.member.entity.Member;
 import com.app.bdink.member.service.MemberService;
 import com.app.bdink.member.util.MemberUtilService;
 import com.app.bdink.openai.dto.request.AiWorkoutMemoReqDto;
+import com.app.bdink.workout.controller.dto.request.WorkoutFeedbackSaveReqDto;
+import com.app.bdink.workout.controller.dto.request.WorkoutFeedbackUploadUrlReqDto;
 import com.app.bdink.workout.controller.dto.request.WorkoutSessionSaveReqDto;
 import com.app.bdink.workout.controller.dto.response.*;
 import com.app.bdink.workout.service.WorkoutService;
@@ -120,9 +122,25 @@ public class WorkoutController {
     public RspTemplate<?> getWorkoutSessionFeedback(Principal principal,
                                                     @PathVariable Long sessionId) {
         Long memberId = memberUtilService.getMemberId(principal);
-        String feedback = workoutService.getWorkoutFeedback(memberId, sessionId);
-        return RspTemplate.success(Success.GET_WORKOUT_SESSION_DETAIL_SUCCESS,
-                com.app.bdink.trainer.controller.dto.response.TrainerFeedbackResponse.of(sessionId, feedback));
+        WorkoutFeedbackResDto dto = workoutService.getWorkoutFeedbackBySession(memberId, sessionId);
+        return RspTemplate.success(Success.GET_WORKOUT_SESSION_DETAIL_SUCCESS, dto);
+    }
+
+    @PostMapping("/{sessionId}/feedback")
+    @Operation(method = "POST", description = "트레이너 피드백을 등록합니다.")
+    public RspTemplate<?> createWorkoutFeedback(Principal principal,
+                                                @PathVariable Long sessionId,
+                                                @RequestBody WorkoutFeedbackSaveReqDto requestDto) {
+        Long trainerId = memberUtilService.getMemberId(principal);
+        WorkoutFeedbackResDto dto = workoutService.saveWorkoutFeedback(trainerId, sessionId, requestDto);
+        return RspTemplate.success(Success.UPDATE_EXERCISELIST_SUCCESS, dto);
+    }
+
+    @PostMapping("/feedback/upload-urls")
+    @Operation(method = "POST", description = "피드백 이미지/영상 업로드용 presigned URL을 발급합니다.")
+    public RspTemplate<?> getWorkoutFeedbackUploadUrls(@RequestBody WorkoutFeedbackUploadUrlReqDto requestDto) {
+        WorkoutFeedbackUploadUrlsResDto dto = workoutService.getWorkoutFeedbackUploadUrls(requestDto);
+        return RspTemplate.success(Success.CREATE_PRESIGNURL_SUCCESS, dto);
     }
 
     @GetMapping("/volume/weeklyCompare")

--- a/bdink/src/main/java/com/app/bdink/workout/controller/dto/request/WorkoutFeedbackMediaReqDto.java
+++ b/bdink/src/main/java/com/app/bdink/workout/controller/dto/request/WorkoutFeedbackMediaReqDto.java
@@ -1,0 +1,11 @@
+package com.app.bdink.workout.controller.dto.request;
+
+import com.app.bdink.workout.entity.WorkoutFeedbackMediaType;
+
+public record WorkoutFeedbackMediaReqDto(
+        WorkoutFeedbackMediaType mediaType,
+        String url,
+        Integer order,
+        String thumbnailUrl
+) {
+}

--- a/bdink/src/main/java/com/app/bdink/workout/controller/dto/request/WorkoutFeedbackSaveReqDto.java
+++ b/bdink/src/main/java/com/app/bdink/workout/controller/dto/request/WorkoutFeedbackSaveReqDto.java
@@ -1,0 +1,9 @@
+package com.app.bdink.workout.controller.dto.request;
+
+import java.util.List;
+
+public record WorkoutFeedbackSaveReqDto(
+        String content,
+        List<WorkoutFeedbackMediaReqDto> media
+) {
+}

--- a/bdink/src/main/java/com/app/bdink/workout/controller/dto/request/WorkoutFeedbackUploadUrlFileReqDto.java
+++ b/bdink/src/main/java/com/app/bdink/workout/controller/dto/request/WorkoutFeedbackUploadUrlFileReqDto.java
@@ -1,0 +1,10 @@
+package com.app.bdink.workout.controller.dto.request;
+
+import com.app.bdink.workout.entity.WorkoutFeedbackMediaType;
+
+public record WorkoutFeedbackUploadUrlFileReqDto(
+        String fileName,
+        String contentType,
+        WorkoutFeedbackMediaType mediaType
+) {
+}

--- a/bdink/src/main/java/com/app/bdink/workout/controller/dto/request/WorkoutFeedbackUploadUrlReqDto.java
+++ b/bdink/src/main/java/com/app/bdink/workout/controller/dto/request/WorkoutFeedbackUploadUrlReqDto.java
@@ -1,0 +1,8 @@
+package com.app.bdink.workout.controller.dto.request;
+
+import java.util.List;
+
+public record WorkoutFeedbackUploadUrlReqDto(
+        List<WorkoutFeedbackUploadUrlFileReqDto> files
+) {
+}

--- a/bdink/src/main/java/com/app/bdink/workout/controller/dto/response/WorkoutFeedbackMediaResDto.java
+++ b/bdink/src/main/java/com/app/bdink/workout/controller/dto/response/WorkoutFeedbackMediaResDto.java
@@ -1,0 +1,11 @@
+package com.app.bdink.workout.controller.dto.response;
+
+import com.app.bdink.workout.entity.WorkoutFeedbackMediaType;
+
+public record WorkoutFeedbackMediaResDto(
+        WorkoutFeedbackMediaType mediaType,
+        String url,
+        Integer order,
+        String thumbnailUrl
+) {
+}

--- a/bdink/src/main/java/com/app/bdink/workout/controller/dto/response/WorkoutFeedbackResDto.java
+++ b/bdink/src/main/java/com/app/bdink/workout/controller/dto/response/WorkoutFeedbackResDto.java
@@ -1,0 +1,12 @@
+package com.app.bdink.workout.controller.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record WorkoutFeedbackResDto(
+        Long sessionId,
+        String content,
+        List<WorkoutFeedbackMediaResDto> media,
+        LocalDateTime createdAt
+) {
+}

--- a/bdink/src/main/java/com/app/bdink/workout/controller/dto/response/WorkoutFeedbackUploadUrlResDto.java
+++ b/bdink/src/main/java/com/app/bdink/workout/controller/dto/response/WorkoutFeedbackUploadUrlResDto.java
@@ -1,0 +1,11 @@
+package com.app.bdink.workout.controller.dto.response;
+
+import com.app.bdink.workout.entity.WorkoutFeedbackMediaType;
+
+public record WorkoutFeedbackUploadUrlResDto(
+        WorkoutFeedbackMediaType mediaType,
+        String fileName,
+        String s3Key,
+        String presignedUrl
+) {
+}

--- a/bdink/src/main/java/com/app/bdink/workout/controller/dto/response/WorkoutFeedbackUploadUrlsResDto.java
+++ b/bdink/src/main/java/com/app/bdink/workout/controller/dto/response/WorkoutFeedbackUploadUrlsResDto.java
@@ -1,0 +1,8 @@
+package com.app.bdink.workout.controller.dto.response;
+
+import java.util.List;
+
+public record WorkoutFeedbackUploadUrlsResDto(
+        List<WorkoutFeedbackUploadUrlResDto> uploadUrls
+) {
+}

--- a/bdink/src/main/java/com/app/bdink/workout/entity/WorkoutFeedback.java
+++ b/bdink/src/main/java/com/app/bdink/workout/entity/WorkoutFeedback.java
@@ -1,0 +1,55 @@
+package com.app.bdink.workout.entity;
+
+import com.app.bdink.common.entity.BaseTimeEntity;
+import com.app.bdink.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class WorkoutFeedback extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "workOutSession_id", nullable = false)
+    private WorkOutSession workOutSession;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trainer_member_id")
+    private Member trainerMember;
+
+    @Column(name = "content", columnDefinition = "TEXT")
+    private String content;
+
+    @OneToMany(mappedBy = "feedback", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<WorkoutFeedbackMedia> mediaList = new ArrayList<>();
+
+    @Builder
+    public WorkoutFeedback(WorkOutSession workOutSession, Member trainerMember, String content) {
+        this.workOutSession = workOutSession;
+        this.trainerMember = trainerMember;
+        this.content = content;
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+    public void addMedia(WorkoutFeedbackMedia media) {
+        this.mediaList.add(media);
+    }
+
+    public void clearMedia() {
+        this.mediaList.clear();
+    }
+}

--- a/bdink/src/main/java/com/app/bdink/workout/entity/WorkoutFeedback.java
+++ b/bdink/src/main/java/com/app/bdink/workout/entity/WorkoutFeedback.java
@@ -25,8 +25,8 @@ public class WorkoutFeedback extends BaseTimeEntity {
     private WorkOutSession workOutSession;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "trainer_member_id")
-    private Member trainerMember;
+    @JoinColumn(name = "trainer_id")
+    private Member trainer;
 
     @Column(name = "content", columnDefinition = "TEXT")
     private String content;
@@ -35,9 +35,9 @@ public class WorkoutFeedback extends BaseTimeEntity {
     private List<WorkoutFeedbackMedia> mediaList = new ArrayList<>();
 
     @Builder
-    public WorkoutFeedback(WorkOutSession workOutSession, Member trainerMember, String content) {
+    public WorkoutFeedback(WorkOutSession workOutSession, Member trainer, String content) {
         this.workOutSession = workOutSession;
-        this.trainerMember = trainerMember;
+        this.trainer = trainer;
         this.content = content;
     }
 

--- a/bdink/src/main/java/com/app/bdink/workout/entity/WorkoutFeedbackMedia.java
+++ b/bdink/src/main/java/com/app/bdink/workout/entity/WorkoutFeedbackMedia.java
@@ -1,0 +1,50 @@
+package com.app.bdink.workout.entity;
+
+import com.app.bdink.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class WorkoutFeedbackMedia extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "feedback_id", nullable = false)
+    private WorkoutFeedback feedback;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "mediaType", nullable = false)
+    private WorkoutFeedbackMediaType mediaType;
+
+    @Column(name = "url", nullable = false)
+    private String url;
+
+    @Column(name = "mediaOrder")
+    private Integer mediaOrder;
+
+    @Column(name = "thumbnailUrl")
+    private String thumbnailUrl;
+
+    @Builder
+    public WorkoutFeedbackMedia(
+            WorkoutFeedback feedback,
+            WorkoutFeedbackMediaType mediaType,
+            String url,
+            Integer mediaOrder,
+            String thumbnailUrl
+    ) {
+        this.feedback = feedback;
+        this.mediaType = mediaType;
+        this.url = url;
+        this.mediaOrder = mediaOrder;
+        this.thumbnailUrl = thumbnailUrl;
+    }
+}

--- a/bdink/src/main/java/com/app/bdink/workout/entity/WorkoutFeedbackMediaType.java
+++ b/bdink/src/main/java/com/app/bdink/workout/entity/WorkoutFeedbackMediaType.java
@@ -1,0 +1,6 @@
+package com.app.bdink.workout.entity;
+
+public enum WorkoutFeedbackMediaType {
+    IMAGE,
+    VIDEO
+}

--- a/bdink/src/main/java/com/app/bdink/workout/repository/WorkoutFeedbackRepository.java
+++ b/bdink/src/main/java/com/app/bdink/workout/repository/WorkoutFeedbackRepository.java
@@ -1,0 +1,10 @@
+package com.app.bdink.workout.repository;
+
+import com.app.bdink.workout.entity.WorkoutFeedback;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface WorkoutFeedbackRepository extends JpaRepository<WorkoutFeedback, Long> {
+    Optional<WorkoutFeedback> findByWorkOutSessionId(Long workOutSessionId);
+}

--- a/bdink/src/main/java/com/app/bdink/workout/service/WorkoutService.java
+++ b/bdink/src/main/java/com/app/bdink/workout/service/WorkoutService.java
@@ -22,14 +22,19 @@ import com.app.bdink.workout.controller.dto.request.ExerciseReqDto;
 import com.app.bdink.workout.controller.dto.request.PerformedExerciseSaveReqDto;
 import com.app.bdink.workout.controller.dto.request.WorkoutSessionSaveReqDto;
 import com.app.bdink.workout.controller.dto.request.WorkoutSetSaveReqDto;
+import com.app.bdink.workout.controller.dto.request.WorkoutFeedbackSaveReqDto;
+import com.app.bdink.workout.controller.dto.request.WorkoutFeedbackMediaReqDto;
 import com.app.bdink.workout.controller.dto.response.*;
 import com.app.bdink.workout.entity.Exercise;
 import com.app.bdink.workout.entity.PerformedExercise;
 import com.app.bdink.workout.entity.WorkOutSession;
+import com.app.bdink.workout.entity.WorkoutFeedback;
+import com.app.bdink.workout.entity.WorkoutFeedbackMedia;
 import com.app.bdink.workout.entity.WorkoutSet;
 import com.app.bdink.workout.repository.ExerciseRepository;
 import com.app.bdink.workout.repository.PerformedExerciseRepository;
 import com.app.bdink.workout.repository.WorkOutSessionRepository;
+import com.app.bdink.workout.repository.WorkoutFeedbackRepository;
 import com.app.bdink.workout.repository.WorkoutSetRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -72,6 +77,7 @@ public class WorkoutService {
     private final PerformedExerciseRepository performedExerciseRepository;
     private final WorkOutSessionRepository workOutSessionRepository;
     private final WorkoutSetRepository workoutSetRepository;
+    private final WorkoutFeedbackRepository workoutFeedbackRepository;
     private final OpenAiChatService openAiChatService;
     private final AiMemoInputLogService aiMemoInputLogService;
     private final ExerciseEmbeddingService exerciseEmbeddingService;
@@ -261,6 +267,96 @@ public class WorkoutService {
     public String getWorkoutFeedback(Long memberId, Long sessionId) {
         WorkOutSession session = findWorkoutSession(sessionId, memberId);
         return session.getFeedback();
+    }
+
+    // 트레이너 피드백 저장(텍스트 + 미디어)
+    @Transactional
+    public WorkoutFeedbackResDto saveWorkoutFeedback(Long trainerId, Long sessionId, WorkoutFeedbackSaveReqDto requestDto) {
+        // 1) 세션/트레이너 조회
+        // - 세션은 id 기준으로 조회
+        // - 트레이너는 memberId로 조회
+        WorkOutSession session = workOutSessionRepository.findById(sessionId).orElseThrow(
+                () -> new CustomException(Error.NOT_FOUND_WORKOUTSESSION, Error.NOT_FOUND_WORKOUTSESSION.getMessage())
+        );
+        Member trainer = memberRepository.findById(trainerId).orElseThrow(
+                () -> new CustomException(Error.NOT_FOUND_USER_EXCEPTION, Error.NOT_FOUND_USER_EXCEPTION.getMessage())
+        );
+
+        // 2) 기존 피드백 있으면 갱신, 없으면 새로 생성
+        WorkoutFeedback feedback = workoutFeedbackRepository.findByWorkOutSessionId(sessionId)
+                .orElseGet(() -> WorkoutFeedback.builder()
+                        .workOutSession(session)
+                        .trainer(trainer)
+                        .content(requestDto.content())
+                        .build());
+
+        // 3) 텍스트 갱신
+        feedback.updateContent(requestDto.content());
+
+        // 4) 기존 미디어 제거 후 새 미디어로 교체 (orphanRemoval)
+        // - 기존 미디어를 모두 비우고
+        // - 요청으로 받은 미디어 리스트를 다시 추가
+        feedback.clearMedia();
+        if (requestDto.media() != null) {
+            for (WorkoutFeedbackMediaReqDto mediaReq : requestDto.media()) {
+                WorkoutFeedbackMedia media = WorkoutFeedbackMedia.builder()
+                        .feedback(feedback)
+                        .mediaType(mediaReq.mediaType())
+                        .url(mediaReq.url())
+                        .mediaOrder(mediaReq.order())
+                        .thumbnailUrl(mediaReq.thumbnailUrl())
+                        .build();
+                feedback.addMedia(media);
+            }
+        }
+
+        // 5) 저장
+        WorkoutFeedback saved = workoutFeedbackRepository.save(feedback);
+
+        // 6) 알림 생성
+        notificationService.create(notificationFactory.create(
+                session.getMember().getId(),
+                NotificationType.WORKOUT_FEEDBACK,
+                "트레이너 피드백",
+                "트레이너 피드백이 도착했어요.",
+                NotificationLinkType.WORKOUT_SESSION,
+                session.getId()
+        ));
+
+        return toWorkoutFeedbackResDto(saved);
+    }
+
+    // 피드백 조회
+    @Transactional(readOnly = true)
+    public WorkoutFeedbackResDto getWorkoutFeedbackBySession(Long memberId, Long sessionId) {
+        // 1) 세션 권한 체크(회원 기준)
+        findWorkoutSession(sessionId, memberId);
+
+        // 2) 피드백 조회
+        WorkoutFeedback feedback = workoutFeedbackRepository.findByWorkOutSessionId(sessionId).orElseThrow(
+                () -> new CustomException(Error.NOT_FOUND, Error.NOT_FOUND.getMessage())
+        );
+
+        return toWorkoutFeedbackResDto(feedback);
+    }
+
+    private WorkoutFeedbackResDto toWorkoutFeedbackResDto(WorkoutFeedback feedback) {
+        List<WorkoutFeedbackMediaResDto> media = feedback.getMediaList().stream()
+                .sorted(Comparator.comparing(m -> m.getMediaOrder() == null ? Integer.MAX_VALUE : m.getMediaOrder()))
+                .map(m -> new WorkoutFeedbackMediaResDto(
+                        m.getMediaType(),
+                        m.getUrl(),
+                        m.getMediaOrder(),
+                        m.getThumbnailUrl()
+                ))
+                .toList();
+
+        return new WorkoutFeedbackResDto(
+                feedback.getWorkOutSession().getId(),
+                feedback.getContent(),
+                media,
+                feedback.getCreatedAt()
+        );
     }
 
     // 월 별 운동일자 기록 조회

--- a/bdink/src/main/java/com/app/bdink/workout/service/WorkoutService.java
+++ b/bdink/src/main/java/com/app/bdink/workout/service/WorkoutService.java
@@ -100,6 +100,8 @@ public class WorkoutService {
     @Value("${ai-memo.rag.distance-threshold}")
     private double ragDistanceThreshold;
 
+    @Value("${aws-property.feedback-cdn-base}")
+    private String feedbackCdnBase;
 
     public Exercise findById(Long id) {
         return exerciseRepository.findById(id).orElseThrow(
@@ -369,7 +371,7 @@ public class WorkoutService {
                 .sorted(Comparator.comparing(m -> m.getMediaOrder() == null ? Integer.MAX_VALUE : m.getMediaOrder()))
                 .map(m -> new WorkoutFeedbackMediaResDto(
                         m.getMediaType(),
-                        m.getUrl(),
+                        toFeedbackMediaUrl(m.getUrl()),
                         m.getMediaOrder(),
                         m.getThumbnailUrl()
                 ))
@@ -381,6 +383,17 @@ public class WorkoutService {
                 media,
                 feedback.getCreatedAt()
         );
+    }
+
+    private String toFeedbackMediaUrl(String urlOrKey) {
+        if (urlOrKey == null || urlOrKey.isBlank()) {
+            return urlOrKey;
+        }
+        if (urlOrKey.startsWith("http://") || urlOrKey.startsWith("https://")) {
+            return urlOrKey;
+        }
+        String base = feedbackCdnBase.endsWith("/") ? feedbackCdnBase : feedbackCdnBase + "/";
+        return base + urlOrKey;
     }
 
     private WorkoutFeedbackUploadUrlResDto createFeedbackUploadUrl(WorkoutFeedbackUploadUrlFileReqDto file) {

--- a/bdink/src/main/java/com/app/bdink/workout/service/WorkoutService.java
+++ b/bdink/src/main/java/com/app/bdink/workout/service/WorkoutService.java
@@ -12,6 +12,7 @@ import com.app.bdink.openai.service.AiMemoInputLogService;
 import com.app.bdink.openai.service.ExerciseEmbeddingService;
 import com.app.bdink.openai.service.ExerciseRagRetrievalService;
 import com.app.bdink.openai.service.OpenAiChatService;
+import com.app.bdink.external.aws.s3.config.S3Config;
 import com.app.bdink.notification.entity.NotificationLinkType;
 import com.app.bdink.notification.entity.NotificationType;
 import com.app.bdink.notification.service.NotificationFactory;
@@ -24,6 +25,8 @@ import com.app.bdink.workout.controller.dto.request.WorkoutSessionSaveReqDto;
 import com.app.bdink.workout.controller.dto.request.WorkoutSetSaveReqDto;
 import com.app.bdink.workout.controller.dto.request.WorkoutFeedbackSaveReqDto;
 import com.app.bdink.workout.controller.dto.request.WorkoutFeedbackMediaReqDto;
+import com.app.bdink.workout.controller.dto.request.WorkoutFeedbackUploadUrlReqDto;
+import com.app.bdink.workout.controller.dto.request.WorkoutFeedbackUploadUrlFileReqDto;
 import com.app.bdink.workout.controller.dto.response.*;
 import com.app.bdink.workout.entity.Exercise;
 import com.app.bdink.workout.entity.PerformedExercise;
@@ -41,8 +44,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
 import java.time.DayOfWeek;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -57,6 +65,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -64,13 +73,13 @@ import java.util.stream.IntStream;
 @Slf4j
 @RequiredArgsConstructor
 public class WorkoutService {
-    @Value("${ai-memo.rag.per-line-topn.short:10}")
+    @Value("${ai-memo.rag.per-line-topn.short}")
     private int ragPerLineTopNShort;
 
-    @Value("${ai-memo.rag.per-line-topn.medium:7}")
+    @Value("${ai-memo.rag.per-line-topn.medium}")
     private int ragPerLineTopNMedium;
 
-    @Value("${ai-memo.rag.per-line-topn.long:5}")
+    @Value("${ai-memo.rag.per-line-topn.long}")
     private int ragPerLineTopNLong;
 
     private final ExerciseRepository exerciseRepository;
@@ -85,6 +94,8 @@ public class WorkoutService {
     private final MemberRepository memberRepository;
     private final NotificationService notificationService;
     private final NotificationFactory notificationFactory;
+    private final S3Presigner s3Presigner;
+    private final S3Config s3Config;
 
     @Value("${ai-memo.rag.distance-threshold}")
     private double ragDistanceThreshold;
@@ -249,6 +260,8 @@ public class WorkoutService {
         return String.valueOf(session.getId());
     }
 
+    // 회원 피드백 수정 로직
+    //todo: 레거시 코드라 삭제 or 주석처리 예정
     @Transactional
     public void updateWorkoutFeedback(Long memberId, Long sessionId, String feedback) {
         WorkOutSession session = findWorkoutSession(sessionId, memberId);
@@ -340,6 +353,17 @@ public class WorkoutService {
         return toWorkoutFeedbackResDto(feedback);
     }
 
+    // 피드백 업로드용 presigned URL 발급
+    @Transactional(readOnly = true)
+    public WorkoutFeedbackUploadUrlsResDto getWorkoutFeedbackUploadUrls(WorkoutFeedbackUploadUrlReqDto requestDto) {
+        // 요청된 파일 수만큼 presigned URL 발급
+        List<WorkoutFeedbackUploadUrlResDto> urls = requestDto.files().stream()
+                .map(this::createFeedbackUploadUrl)
+                .toList();
+
+        return new WorkoutFeedbackUploadUrlsResDto(urls);
+    }
+
     private WorkoutFeedbackResDto toWorkoutFeedbackResDto(WorkoutFeedback feedback) {
         List<WorkoutFeedbackMediaResDto> media = feedback.getMediaList().stream()
                 .sorted(Comparator.comparing(m -> m.getMediaOrder() == null ? Integer.MAX_VALUE : m.getMediaOrder()))
@@ -356,6 +380,39 @@ public class WorkoutService {
                 feedback.getContent(),
                 media,
                 feedback.getCreatedAt()
+        );
+    }
+
+    private WorkoutFeedbackUploadUrlResDto createFeedbackUploadUrl(WorkoutFeedbackUploadUrlFileReqDto file) {
+        // 파일 확장자 보존 + UUID로 새로운 파일명 생성
+        String extension = "";
+        String originalFileName = file.fileName();
+        int dotIndex = originalFileName.lastIndexOf(".");
+        if (dotIndex > -1) {
+            extension = originalFileName.substring(dotIndex);
+        }
+
+        String newFileName = UUID.randomUUID() + extension;
+        String key = "feedback/" + newFileName;
+
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(s3Config.getS3Bucket())
+                .key(key)
+                .contentType(file.contentType())
+                .build();
+
+        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(10))
+                .putObjectRequest(putObjectRequest)
+                .build();
+
+        PresignedPutObjectRequest presigned = s3Presigner.presignPutObject(presignRequest);
+
+        return new WorkoutFeedbackUploadUrlResDto(
+                file.mediaType(),
+                originalFileName,
+                key,
+                presigned.url().toString()
         );
     }
 


### PR DESCRIPTION
## 이슈번호
- #452 

## 작업 내용 
- 운동일지 피드백 관련 엔티티 및 관련 enum 생성
- Feedback 생성 및 업로드 관련 Dto 생성
- 트레이너 피드백 저장, 조회 비즈니스 로직 생성
- s3 presigend Url 방식 사용하여 사진 및 업로드 api 생성
- ResDto에 CloudFrnot 주소를 포함한 전체 url 필드 생성