### PR TITLE
[Bug] SessionId를 통한 회원 피드백 내용 조회 실패 현상

### DIFF
--- a/bdink/src/main/java/com/app/bdink/workout/controller/WorkoutController.java
+++ b/bdink/src/main/java/com/app/bdink/workout/controller/WorkoutController.java
@@ -119,10 +119,8 @@ public class WorkoutController {
 
     @GetMapping("/{sessionId}/feedback")
     @Operation(method = "GET", description = "운동일지 피드백을 세션 ID로 조회합니다.")
-    public RspTemplate<?> getWorkoutSessionFeedback(Principal principal,
-                                                    @PathVariable Long sessionId) {
-        Long memberId = memberUtilService.getMemberId(principal);
-        WorkoutFeedbackResDto dto = workoutService.getWorkoutFeedbackBySession(memberId, sessionId);
+    public RspTemplate<?> getWorkoutSessionFeedback(@PathVariable Long sessionId) {
+        WorkoutFeedbackResDto dto = workoutService.getWorkoutFeedbackBySession(sessionId);
         return RspTemplate.success(Success.GET_WORKOUT_SESSION_DETAIL_SUCCESS, dto);
     }
 

--- a/bdink/src/main/java/com/app/bdink/workout/service/WorkoutService.java
+++ b/bdink/src/main/java/com/app/bdink/workout/service/WorkoutService.java
@@ -121,6 +121,12 @@ public class WorkoutService {
         );
     }
 
+    public WorkOutSession findWorkoutSessionById(Long id) {
+        return workOutSessionRepository.findById(id).orElseThrow(
+                () -> new CustomException(Error.NOT_FOUND_WORKOUTSESSION, Error.NOT_FOUND_WORKOUTSESSION.getMessage())
+        );
+    }
+
     public String createExercise(ExerciseReqDto exerciseReqDto,
                                  String exerciseVideoUrl,
                                  String exercisePictureUrl
@@ -343,9 +349,9 @@ public class WorkoutService {
 
     // 피드백 조회
     @Transactional(readOnly = true)
-    public WorkoutFeedbackResDto getWorkoutFeedbackBySession(Long memberId, Long sessionId) {
-        // 1) 세션 권한 체크(회원 기준)
-        findWorkoutSession(sessionId, memberId);
+    public WorkoutFeedbackResDto getWorkoutFeedbackBySession(Long sessionId) {
+        // 1) 세션이 존재하는지 체크
+        findWorkoutSessionById(sessionId);
 
         // 2) 피드백 조회
         WorkoutFeedback feedback = workoutFeedbackRepository.findByWorkOutSessionId(sessionId).orElseThrow(


### PR DESCRIPTION
## 이슈번호
- #454 

## 작업 내용
- 피드백 조회시 멤버아이디와 sessionId의 조합이 아닌 sessionId를 통한 조회로 로직 변경