### PR TITLE
[Chore] CORS 허용 도메인에 localhost:3000, www.bdink.co.kr 추가 #496

### DIFF
--- a/bdink/src/main/java/com/app/bdink/global/config/SecurityConfig.java
+++ b/bdink/src/main/java/com/app/bdink/global/config/SecurityConfig.java
@@ -77,7 +77,12 @@ public class SecurityConfig {
         CorsConfiguration configuration = new CorsConfiguration();
 
         configuration.setAllowedOriginPatterns(List.of("*")); // 모든 도메인에서의 요청 허용
-        configuration.setAllowedOrigins(List.of("http://127.0.0.1:3000","http://127.0.0.1:8080"));
+        configuration.setAllowedOrigins(List.of(
+                "http://127.0.0.1:3000",
+                "http://127.0.0.1:8080",
+                "http://localhost:3000",
+                "https://www.bdink.co.kr"
+        ));
         configuration.setAllowedHeaders(List.of("*")); // 모든 헤더 요청 허용
         configuration.setExposedHeaders(List.of("Access-Control-Allow-Credentials", "Authorization", "Set-Cookie")); // 특정 응답 헤더를 클라이언트가 접근할 수 있도록 노출
         configuration.setAllowCredentials(true); // 자격 증명(쿠기 등)을 포함한 요청 허용


### PR DESCRIPTION
웹앱에서 /api/v1/payments/confirm 등 API 호출 시 CORS로 막히는 문제 발견.
기존에는 127.0.0.1만 허용되어 있어 localhost와 origin이 달라 차단됨.
localhost:3000(로컬 개발용), www.bdink.co.kr(추후 배포용) 추가.